### PR TITLE
Handle an older version of Plotly which does not have Scatter.offsetg…

### DIFF
--- a/app/ui/reports_dbt.py
+++ b/app/ui/reports_dbt.py
@@ -114,7 +114,6 @@ where
                     y=dfc["RunId"],
                     name="Run Count",
                     yaxis="y2",
-                    offsetgroup=2,
                     marker_color="#856CF3",
                 ),
             ],


### PR DESCRIPTION
…roup

When not running locally, it appears that we get an older version of plotly which does not have the offsetgroup atribute on Scatter. However, the offsetgroup does not seem to be important since we want the bar and scatter plot to render on top of each other.

This change was introduced in plotly v5.12.0, so we must be running v5.11.0 or older.