### PR TITLE
Change pr workflow to pull_request_target

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,17 +1,16 @@
 name: PR Build Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
-
-env:
-  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v3
         with:
           python-version: '3.8'
@@ -22,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
       - uses: actions/setup-python@v3
         with:


### PR DESCRIPTION
Makes sure the repository secrets are available to the workflow, but makes it more important that we trust PR authors (via https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks#approving-workflow-runs-on-a-pull-request-from-a-public-fork). The workflow is triggering using `main` on opscenter.git, but the deploy is run against the pull request branch.

This enables potential bad actors who send us one good pull request, but let's assume those are few and far between.