### PR TITLE
Fix hardcoded wait time in Settings/Reset tab.

### DIFF
--- a/cypress/e2e/settings.spec.cy.js
+++ b/cypress/e2e/settings.spec.cy.js
@@ -58,8 +58,6 @@ describe("Settings section", () => {
     buttonClick("Reset and reload query history and warehouse events.");
     checkNoErrorOnThePage();
 
-    // TODO: this wait is temporary until we figure out how to wait in cypress for element to disappear
-    cy.wait(30000);
     checkSuccessAlert("Reset Complete.");
 
   });

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -17,9 +17,9 @@ export function checkNoErrorOnThePage() {
 
 // Check for Success notification with particular text presence
 export function checkSuccessAlert(notificationText) {
-  cy.get('div[role="alert"][data-baseweb="notification"]')
-    .should("exist")
-    .contains(notificationText);
+  cy.get('div[role="alert"][data-baseweb="notification"]', { timeout: 60000 })
+    .and('contain', notificationText);
+
 };
 
 export const fillInProbeForm = (


### PR DESCRIPTION
Issue #38 (part 1) - fix Settings/Reset tab test, remove hardcoded wait. 

This timeout is a correct implementation, as it waits for up to N seconds specified in { timeout: N } per get() call.
<img width="999" alt="Cypress-retriability" src="https://github.com/sundeck-io/OpsCenter/assets/104043363/0b021df4-302f-4f58-b25a-e735b3ba86ce">

I'm working on removing rest of the incorrectly placed cy.wait() calls, would like to merge this change first as I can see this particular test consistently failing in the regression runs.