### PR TITLE
Enabled probes test.

### DIFF
--- a/cypress/e2e/probes.spec.cy.js
+++ b/cypress/e2e/probes.spec.cy.js
@@ -5,7 +5,7 @@ describe("Probes section", () => {
     setup();
   });
 
-  it.skip("Menu: Probes", () => {
+  it("Menu: Probes", () => {
     cy.visit("/");
 
     cy.get("span")


### PR DESCRIPTION
Test was not runnable due to a missing setup step: call {conn.database}.ADMIN.FINALIZE_SETUP(); (already addressed in commit 934e60ad)

Closes  #37.