### PR TITLE
Slack probe notifications

### DIFF
--- a/app/ui/probes.py
+++ b/app/ui/probes.py
@@ -95,7 +95,7 @@ class Probe:
 
             with columns[4]:
                 st.text(row["NOTIFY_OTHER"])
-                if len(row['NOTIFY_OTHER']) > 0:
+                if len(row["NOTIFY_OTHER"]) > 0:
                     st.write(f"via {row['NOTIFY_OTHER_METHOD'].capitalize()}")
 
             with columns[5]:
@@ -121,7 +121,16 @@ class Probe:
 
         st.button("New", key="create", on_click=self.session.do_create, args=[None])
 
-    def on_create_click(self, name, condition, notify_writer, notify_writer_method, notify_other, notify_other_method, cancel):
+    def on_create_click(
+        self,
+        name,
+        condition,
+        notify_writer,
+        notify_writer_method,
+        notify_other,
+        notify_other_method,
+        cancel,
+    ):
         with st.spinner("Creating new probe..."):
             outcome = self.snowflake.call(
                 "ADMIN.CREATE_PROBE",
@@ -142,7 +151,15 @@ class Probe:
         self.status.error(outcome)
 
     def on_update_click(
-        self, oldname, name, condition, notify_writer, notify_writer_method, notify_other, notify_other_method, cancel
+        self,
+        oldname,
+        name,
+        condition,
+        notify_writer,
+        notify_writer_method,
+        notify_other,
+        notify_other_method,
+        cancel,
     ):
         outcome = None
         with st.spinner("Updating probe..."):
@@ -197,7 +214,15 @@ class Probe:
         st.button(
             "Create",
             on_click=self.on_create_click,
-            args=[name, condition, notify_writer, notify_writer_method, notify_other, notify_other_method, cancel],
+            args=[
+                name,
+                condition,
+                notify_writer,
+                notify_writer_method,
+                notify_other,
+                notify_other_method,
+                cancel,
+            ],
         )
         st.button("Cancel", on_click=self.session.do_list)
 
@@ -217,7 +242,7 @@ class Probe:
                 key="NOTIFY_WRITER_METHOD",
                 label="via",
                 options=("Email", "Slack"),
-                index=1 if update["notify_writer_method"].lower() == 'slack' else 0,
+                index=1 if update["notify_writer_method"].lower() == "slack" else 0,
             )
             st.divider()
             cancel = st.checkbox(
@@ -233,13 +258,22 @@ class Probe:
                 key="NOTIFY_OTHER_METHOD",
                 label="via",
                 options=("Email", "Slack"),
-                index=1 if update["notify_other_method"].lower() == 'slack' else 0,
+                index=1 if update["notify_other_method"].lower() == "slack" else 0,
             )
 
         st.button(
             "Update",
             on_click=self.on_update_click,
-            args=[update["name"], name, condition, notify_writer, notify_writer_method, notify_other, notify_other_method, cancel],
+            args=[
+                update["name"],
+                name,
+                condition,
+                notify_writer,
+                notify_writer_method,
+                notify_other,
+                notify_other_method,
+                cancel,
+            ],
         )
         st.button("Cancel", on_click=self.session.do_list)
 

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -43,7 +43,7 @@ export const fillInProbeForm = (
   if (emailTheAuthor) {
     // check({force: true}) - explanation below
     // https://docs.cypress.io/guides/references/error-messages#cy-failed-because-the-element-cannot-be-interacted-with
-    cy.get('input[aria-label="Email the author"]')
+    cy.get('input[aria-label="Notify the author"]')
       .should("exist")
       .check({ force: true });
   }
@@ -54,7 +54,7 @@ export const fillInProbeForm = (
       .check({ force: true });
   }
 
-  cy.get('textarea[aria-label="Email others (comma delimited)"]')
+  cy.get('textarea[aria-label="Notify others (comma delimited)"]')
     .clear()
     .type(emailOthers);
 };


### PR DESCRIPTION
Each probe now has an option to choose one of 'Email' or 'Slack' for 'Notify the author' and 'Notify others'.

Sundeck is providing one external function and a Slack app that can be installed if you create a Sundeck account.

'Notify the author' for Slack depends on the email address you have for Snowflake matching the email address on your Slack profile in the workspace you've installed the Sundeck app to. 'Notify others' can accept Slack user's email addresses, slack usernames, and channel names.

The INTERNAL.PROBES table has to be migrated to handle the "mechanism" for each method of notification. A procedure will perform that migration in an idempotent fashion, defaulting all existing probe notifications to be 'Email' notifications.

Closes #25, #74

<img width="1575" alt="Screenshot 2023-07-27 at 7 35 05 PM" src="https://github.com/sundeck-io/OpsCenter/assets/67863/a1ee11f7-658b-47c0-ba1a-8c2d11c56135">
<img width="500" alt="Screenshot 2023-07-27 at 7 35 16 PM" src="https://github.com/sundeck-io/OpsCenter/assets/67863/8fc2b4b9-4fbd-4702-8d4d-001d3d5e4d9d">

