### PR TITLE
Move from conda to poetry and update versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: streamlit_env
+channels:
+  - https://repo.anaconda.com/pkgs/snowflake
+  - defaults
+dependencies:
+  - python=3.10
+  - streamlit=1.16
+  - plotly=5.0
+  - snowflake-snowpark-python=1.5.1
+  - pandas


### PR DESCRIPTION
This introduces conda and updates to python 3.10

We still have to:
* [ ] update actions
* [x] update readme
* [ ] test 3.10
* [x] remove poetry

closes #34 and #36