### PR TITLE
OPSCENTER-41: Avoid big exception stacktrace when configuration is no…

### DIFF
--- a/app/ui/pages/10_Settings.py
+++ b/app/ui/pages/10_Settings.py
@@ -84,25 +84,26 @@ with config_tab:
             ):
                 st.error("Please enter a valid number for all costs.")
 
-            config.set_costs(compute, serverless, storage)
-            connection.execute(
-                f"""
-            BEGIN
-                CREATE OR REPLACE FUNCTION INTERNAL.GET_CREDIT_COST()
-                    RETURNS NUMBER AS
-                    $${compute}$$;
+            else:
+                config.set_costs(compute, serverless, storage)
+                connection.execute(
+                    f"""
+                BEGIN
+                    CREATE OR REPLACE FUNCTION INTERNAL.GET_CREDIT_COST()
+                        RETURNS NUMBER AS
+                        $${compute}$$;
 
-                CREATE OR REPLACE FUNCTION INTERNAL.GET_SERVERLESS_CREDIT_COST()
-                    RETURNS NUMBER AS
-                    $${serverless}$$;
+                    CREATE OR REPLACE FUNCTION INTERNAL.GET_SERVERLESS_CREDIT_COST()
+                        RETURNS NUMBER AS
+                        $${serverless}$$;
 
-                CREATE OR REPLACE FUNCTION INTERNAL.GET_STORAGE_COST()
-                    RETURNS NUMBER AS
-                    $${storage}$$;
-            END;
-            """
-            )
-            st.success("Saved")
+                    CREATE OR REPLACE FUNCTION INTERNAL.GET_STORAGE_COST()
+                        RETURNS NUMBER AS
+                        $${storage}$$;
+                END;
+                """
+                )
+                st.success("Saved")
 
 
 with setup_tab:


### PR DESCRIPTION
…t a valid number

Previously, when configuration input is not a valid number, it will return error msg `Please enter a valid number for all costs.`, and continue to execute with the wrong formatted input, and hit the following big exception stacktrace.

close #41

<img width="934" alt="Screen Shot 2023-08-01 at 9 54 47 AM" src="https://github.com/sundeck-io/OpsCenter/assets/5742011/091e4396-5c7d-41e3-818b-693adc5a5566">

With the fix, it will only return error msg `Please enter a valid number for all costs.`.
<img width="399" alt="Screen Shot 2023-08-01 at 10 15 10 AM" src="https://github.com/sundeck-io/OpsCenter/assets/5742011/9040843d-4c8d-4759-836b-c6552c09c135">
