### PR TITLE
Include the probe name which matched in Slack notification message

### DIFF
--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -117,6 +117,7 @@ BEGIN
             let slackResult string := '';
             let dict variant := OBJECT_CONSTRUCT('bt', CHAR(UNICODE('\u0060')), 'query_id', act.query_id, 'query_text', act.query_text, 'user_name', act.user_name, 'warehouse_name', act.warehouse_name, 'start_time', act.start_time, 'probe_name', act.probe_name);
             let message string := '
+Sundeck OpsCenter probe [{probe_name}] matched query.\n
 Query Id: {bt}{query_id}{bt}\n
 Query User: {user_name}\n
 Warehouse Name: {bt}{warehouse_name}{bt}\n


### PR DESCRIPTION
@vqmarkman you had mentioned this elsewhere that we're missing the probe name which created the notification in the Slack path.

Simple change to copy the subject from the email notification to match the slack notification.