### PR TITLE
Do not pass quoted security integration name to SHOW_OAUTH_CLIENT_SEC…

### DIFF
--- a/app/ui/setup.py
+++ b/app/ui/setup.py
@@ -252,13 +252,19 @@ def sundeck_signup_with_snowflake_sso(
 def generate_code_to_create_sundeck_account(
     db: str, sf_region: str, sd_deployment: str
 ) -> str:
-    security_integration_name = '"Sundeck"'
+    # The case-sensitive security integration name
+    security_integration_name = 'Sundeck'
     if sd_deployment != "prod":
-        security_integration_name = f'"SUNDECK_OAUTH_{db.upper()}"'
+        security_integration_name = f'SUNDECK_OAUTH_{db.upper()}'
+
+    # A quoted version of the name to ensure the security integration has verbatim casing
+    # We cannot pass the quoted name to `generate_register_tenant_code` because the
+    # SHOW_OAUTH_CLIENT_SECRETS function cannot handle the extra quotes.
+    quoted_name = f'"{security_integration_name}"'
 
     return f"""
 BEGIN  -- Create security integration and Sundeck account
-{generate_security_integration_code(sf_region, sd_deployment, security_integration_name)}
+{generate_security_integration_code(sf_region, sd_deployment, quoted_name)}
 {generate_register_tenant_code(db, security_integration_name)}
 END;
 """

--- a/app/ui/setup.py
+++ b/app/ui/setup.py
@@ -253,9 +253,9 @@ def generate_code_to_create_sundeck_account(
     db: str, sf_region: str, sd_deployment: str
 ) -> str:
     # The case-sensitive security integration name
-    security_integration_name = 'Sundeck'
+    security_integration_name = "Sundeck"
     if sd_deployment != "prod":
-        security_integration_name = f'SUNDECK_OAUTH_{db.upper()}'
+        security_integration_name = f"SUNDECK_OAUTH_{db.upper()}"
 
     # A quoted version of the name to ensure the security integration has verbatim casing
     # We cannot pass the quoted name to `generate_register_tenant_code` because the


### PR DESCRIPTION
…RETS

Regression from #145

The quoting of the security integration name works fine. However, the SYSTEM$SHOW_OAUTH_CLIENT_SECRETS function cannot handle the double-quotes inside of the integration name.