### PR TITLE
Pin streamlit to 1.22.x, should fix cypress

### DIFF
--- a/app/ui/environment.yml
+++ b/app/ui/environment.yml
@@ -6,3 +6,4 @@ dependencies:
 - plotly
 - altair
 - snowflake-native-apps-permission
+- streamlit=1.22.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "~3.8"
 plotly = "~5.11"
-streamlit = "^1.16.0"
+streamlit = "~1.22"
 snowflake-snowpark-python = { version = "^1.5.1", extras = ["pandas"] }
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This matches what is currently in snowflake.information_schema.packages

When I talked to Vicky on Friday, she had figured out that the version of streamlit in SF had changed since end of June when we last checked. Cypress was failing because of a streamlit stacktrace being printed, which I believe stems from the wrong dep version string for streamlit in pyproject.toml (we wanted "nothing more recent than 1.16" but had "anything newer than 1.16".

The rest of us hadn't noticed because of the poetry.lock we already had (likely at streamlit 1.22.x or 1.24.x)