### PR TITLE
Correct the ordering of DAILY and COMPLETE for PERIOD_PLUS

### DIFF
--- a/bootstrap/015_warehouse_views.sql
+++ b/bootstrap/015_warehouse_views.sql
@@ -99,8 +99,9 @@ SELECT
     SESSION_ID,
     session_start,
     session_end,
+    -- See comment in 017_query_history.sql about PERIOD_PLUS
     DATEDIFF('day', session_start, session_end) + 1 AS PERIOD_PLUS,
-    IFF(index = PERIOD_PLUS, 'DAILY', 'COMPLETE') AS RECORD_TYPE,
+    IFF(index = PERIOD_PLUS, 'COMPLETE', 'DAILY') AS RECORD_TYPE,
     IFF(index in (0, PERIOD_PLUS), session_start, dateadd('day', index, date_trunc('day', session_start))) as ST,
     IFF(index in (PERIOD_PLUS - 1, PERIOD_PLUS), session_end, least(CURRENT_TIMESTAMP(), dateadd('day', index + 1, date_trunc('day', session_end)))) as ET,
     date_trunc('day', ST) AS ST_PERIOD,

--- a/bootstrap/017_query_history.sql
+++ b/bootstrap/017_query_history.sql
@@ -14,8 +14,11 @@ BEGIN
         SELECT
             current_timestamp() as run_id,
             tools.qtag(query_text, true, true) as qtag,
+            -- We emit N+1 rows for the number of days a query spans (e.g. a query spans 1 day, PERIOD_PLUS is 2. A query spans 2 days, PERIOD_PLUS is 3)
+            -- This logic is also in 015_warehouse_views.sql
             DATEDIFF('day', START_TIME, END_TIME) + 1 AS PERIOD_PLUS,
-            IFF(index = PERIOD_PLUS, 'DAILY', 'COMPLETE') AS RECORD_TYPE,
+            -- [0, PERIOD_PLUS) are the daily bins for this query, PERIOD_PLUS is the complete query
+            IFF(index = PERIOD_PLUS, 'COMPLETE', 'DAILY') AS RECORD_TYPE,
             IFF(index in (0, PERIOD_PLUS), start_time, dateadd('day', index, date_trunc('day', start_time))) as ST,
             IFF(index in (PERIOD_PLUS - 1, PERIOD_PLUS), end_time, least(CURRENT_TIMESTAMP(), dateadd('day', index + 1, date_trunc('day', start_time)))) as ET,
             date_trunc('day', ST) AS ST_PERIOD,


### PR DESCRIPTION
This bug causes the binning of queries by day to be backwards; the "total" query row was sent to the DAILY view and the rows per day for a query were sent to the COMPLETE view.

Verified on existing installations that this fix only applies to newly captured queries and does not rewrite old queries (confirmed by the metrics in internal.task_query_history table)

Closes #143

Some "proof" for the verification around not-regenerating the entire query history. here is the output from `select * from internal.task_query_history`

```
RUN	SUCCESS	INPUT	OUTPUT
2023-08-29 15:17:33.511	TRUE		{   "attempted_migrate": true,   "new_INCOMPLETE": 2,   "new_closed": 21124162,   "new_records": 21124164,   "newest_completed": "2023-08-29 14:32:33.459",   "oldest_running": "2023-08-29 14:32:33.459" }
2023-08-29 15:33:53.493	TRUE	{   "attempted_migrate": true,   "new_INCOMPLETE": 2,   "new_closed": 21124162,   "new_records": 21124164,   "newest_completed": "2023-08-29 14:32:33.459",   "oldest_running": "2023-08-29 14:32:33.459" }	{   "attempted_migrate": true,   "new_INCOMPLETE": 2,   "new_closed": 1572,   "new_records": 1574,   "newest_completed": "2023-08-29 14:48:41.623",   "oldest_running": "2023-08-29 14:48:41.623" }
2023-08-29 15:41:01.515	TRUE	{   "attempted_migrate": true,   "new_INCOMPLETE": 2,   "new_closed": 1572,   "new_records": 1574,   "newest_completed": "2023-08-29 14:48:41.623",   "oldest_running": "2023-08-29 14:48:41.623" }	{   "attempted_migrate": true,   "new_INCOMPLETE": 2,   "new_closed": 884,   "new_records": 886,   "newest_completed": "2023-08-29 14:55:42.678",   "oldest_running": "2023-08-29 14:55:42.678" }
```

Row 1: unpatched fresh computation after a "Reset" (v1.17)
Row 2: first run after fixing this bug for QH and WH
Row 3: a second run to verify that subsequent runs also don't "rewind"

The `OUTPUT` column on rows 2 and 3 are demonstrating that we are not re-reading all ~21M rows in this account's query_history view.