### PR TITLE
Try to stabilize the snowpark odd errors

### DIFF
--- a/app/ui/connection.py
+++ b/app/ui/connection.py
@@ -83,8 +83,7 @@ class Connection:
                         "schema": schema,
                     }
 
-                    Session.builder.configs(connection_parameters).create()
-                    cls.session = get_active_session()
+                    cls.session = Session.builder.configs(connection_parameters).create()
             return cls.session
 
     @staticmethod

--- a/app/ui/connection.py
+++ b/app/ui/connection.py
@@ -83,7 +83,9 @@ class Connection:
                         "schema": schema,
                     }
 
-                    cls.session = Session.builder.configs(connection_parameters).create()
+                    cls.session = Session.builder.configs(
+                        connection_parameters
+                    ).create()
             return cls.session
 
     @staticmethod

--- a/app/ui/reports_heatmap.py
+++ b/app/ui/reports_heatmap.py
@@ -31,7 +31,7 @@ def heatmap(
     high = (
         bf.end - datetime.timedelta(days=bf.end.weekday()) + datetime.timedelta(days=6)
     )
-    df = connection.execute(
+    df = connection.execute_select(
         sql, {"start": low, "end": high, "warehouse_names": bf.warehouse_names}
     )
     df.set_index(["PERIOD"], inplace=True)

--- a/app/ui/reports_warehouse.py
+++ b/app/ui/reports_warehouse.py
@@ -147,7 +147,7 @@ def report(
             group by warehouse_id, warehouse_name, st_period;
             """
 
-        df = connection.execute(
+        df = connection.execute_select(
             sql,
             {"start": bf.start, "end": bf.end, "warehouse_names": bf.warehouse_names},
         )

--- a/app/ui/setup.py
+++ b/app/ui/setup.py
@@ -45,7 +45,7 @@ def decode_token(token: str):
 
 
 def setup_permissions():
-    db = connection.execute("select current_database() as db").values[0][0]
+    db = connection.execute_select("select current_database() as db").values[0][0]
 
     privileges = [
         "EXECUTE MANAGED TASK",
@@ -64,7 +64,7 @@ def setup_permissions():
 def setup_block():
 
     db, account, user, sf_region, sd_deployment = list(
-        connection.execute(
+        connection.execute_select(
             """select current_database() as db,
         current_account() as account,
         current_user() as username,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 python = "~3.8"
 plotly = "~5.11"
 streamlit = "~1.22"
-snowflake-snowpark-python = { version = "^1.5.1", extras = ["pandas"] }
+snowflake-snowpark-python = { version = "~1.5.1", extras = ["pandas"] }
 
 [tool.poetry.group.dev.dependencies]
 watchdog = "^3.0.0"


### PR DESCRIPTION
* Cache the Session returned by Session.builder.create()
* Properly pin snowpark to use 1.5.1 (latest in INFORMATION_SCHEMA.PACKAGES)
* Use the `execute_select` variant on Connection which calls `to_pandas()`

Aggressively clicking locally prior to this change, would result in an exception every ~5 page views. After this change, I've yet to get an exception on the page (one in the console, though). I'm not sure what about the non `is_select` branch is giving us grief though.

rel #35

I'm a little suspect of this, not knowing _what_ exactly was cranky in that else branch. Food for thought for now. Curious if it helps devdeploy+local streamlit for y'all too.