### PR TITLE
Basic wiring of pytests into workflow

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,6 +15,44 @@ jobs:
           python-version: '3.8'
           cache: 'pip'
       - uses: pre-commit/action@v3.0.0
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: recursive
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+          cache: 'pip'
+      - name: install dependencies
+        run: |
+          pip install poetry
+          poetry install --with=dev
+      - name: Make unique names for this job
+        id: shell-command
+        run: |
+          SUFFIX=$(echo ${GITHUB_HEAD_REF} | sed "s/\./_/g" | sed "s/-/_/g" | sed "s\/\_\g")_${GITHUB_RUN_ID}
+          echo "OPSCENTER_DATABASE=UNIT_TESTS_$SUFFIX" >> $GITHUB_ENV
+      - name: Make snowsql config
+        env:
+          # Also uses OPSCENTER_DATABASE from above
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+        run: |
+          mkdir $HOME/.snowsql
+          envsubst < deploy/opscenter.config > $HOME/.snowsql/config
+      - name: Run deploy/devdeploy.py (without triggering materializations)
+        run: poetry run python deploy/devdeploy.py --profile opscenter --skip-finish-setup
+      - name: Run pytests
+        run: cd test && poetry run python -m pytest unit --profile opscenter
+      - name: Cleanup Snowflake database
+        run: poetry run python deploy/cypress_teardown.py --profile opscenter
+      - name: Cleanup Snowflake database
+        if: failure()
+        run: poetry run python deploy/cypress_teardown.py --profile opscenter
   test-deploy:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,5 @@ snowflake-snowpark-python = { version = "^1.5.1", extras = ["pandas"] }
 
 [tool.poetry.group.dev.dependencies]
 watchdog = "^3.0.0"
+pytest = "^7.4.1"
+snowflake-connector-python = "^3.1.1"


### PR DESCRIPTION
Uses conda and its own database via `devdeploy.py -s` (skipping materialization to keep costs and execution time down).

Rel #169

test/README.md was a little sparse on how to actually run the tests (e.g. what are the python dependencies, what needs to exist in snowflake), so I made some educated guesses to fill in the gap. If those are correct, I will update the README.

This passed for me in my fork https://github.com/joshelser/OpsCenter/actions/runs/6067975974/job/16460330862?pr=3