### PR TITLE
Correctly use snowflake schema as base schema

### DIFF
--- a/bootstrap/018_warehouse_updates.sql
+++ b/bootstrap/018_warehouse_updates.sql
@@ -18,6 +18,22 @@ EXCEPTION
 END;
 call internal.migrate_warehouse_size_mapping();
 
+CREATE OR REPLACE PROCEDURE internal.migrate_warehouse_events()
+returns variant
+language sql
+as
+begin
+    SYSTEM$LOG_TRACE('Migrating warehouse events data.');
+    call internal.migrate_if_necessary('INTERNAL_REPORTING', 'CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY', 'INTERNAL_REPORTING_MV', 'CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY');
+    let migrate1 variant := (select * from TABLE(RESULT_SCAN(LAST_QUERY_ID())));
+    call internal.migrate_if_necessary('INTERNAL_REPORTING', 'CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY', 'INTERNAL_REPORTING_MV', 'CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY_INCOMPLETE');
+    let migrate2 variant := (select * from TABLE(RESULT_SCAN(LAST_QUERY_ID())));
+    -- Ensure that RECORD_TYPE is VARCHAR and not VARCHAR(8)
+    ALTER TABLE INTERNAL_REPORTING_MV.CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY MODIFY COLUMN RECORD_TYPE TYPE VARCHAR;
+    ALTER TABLE INTERNAL_REPORTING_MV.CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY_INCOMPLETE MODIFY COLUMN RECORD_TYPE TYPE VARCHAR;
+    return object_construct('migrate1', migrate1, 'migrate2', migrate2);
+end;
+
 CREATE OR REPLACE PROCEDURE internal.refresh_warehouse_events(migrate boolean) RETURNS STRING LANGUAGE SQL
     COMMENT = 'Refreshes the warehouse events materialized view. If migrate is true, then the materialized view will be migrated if necessary.'
     AS
@@ -27,14 +43,10 @@ BEGIN
     let migrate1 string := null;
     let migrate2 string := null;
     if (migrate) then
-        SYSTEM$LOG_TRACE('Migrating warehouse events data.');
-        call internal.migrate_if_necessary('INTERNAL_REPORTING', 'CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY', 'INTERNAL_REPORTING_MV', 'CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY');
-        migrate1 := (select * from TABLE(RESULT_SCAN(LAST_QUERY_ID())));
-        call internal.migrate_if_necessary('INTERNAL_REPORTING', 'CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY', 'INTERNAL_REPORTING_MV', 'CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY_INCOMPLETE');
-        migrate2 := (select * from TABLE(RESULT_SCAN(LAST_QUERY_ID())));
-        -- Ensure that RECORD_TYPE is VARCHAR and not VARCHAR(8)
-        ALTER TABLE INTERNAL_REPORTING_MV.CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY MODIFY COLUMN RECORD_TYPE TYPE VARCHAR;
-        ALTER TABLE INTERNAL_REPORTING_MV.CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY_INCOMPLETE MODIFY COLUMN RECORD_TYPE TYPE VARCHAR;
+        let migrate_result variant variant;
+        call internal.migrate_warehouse_events() into migrate_result;
+        migrate1 := migrate_result:migrate1::string;
+        migrate2 := migrate_result:migrate2::string;
     end if;
 
     let input variant := null;

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -32,6 +32,9 @@ BEGIN
             END FOR;
         END;
     END;
+call internal.migrate_queries();
+call internal.migrate_warehouse_events();
+call internal.migrate_view();
 
 -- These can't be created until after EXECUTE MANAGED TASK is granted to application.
 CREATE OR REPLACE TASK TASKS.WAREHOUSE_EVENTS_MAINTENANCE

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -11,8 +11,8 @@ BEGIN
           c1 CURSOR FOR
               with columns as (
                 select table_schema, table_name, LISTAGG('"' || COLUMN_NAME || '" ', ', \n') WITHIN GROUP (ORDER BY ORDINAL_POSITION) as cols
-                from information_schema.columns
-                where table_catalog = current_database() and table_schema in ('ACCOUNT_USAGE', 'ORGANIZATION_USAGE')
+                from snowflake.information_schema.columns
+                where table_catalog = 'SNOWFLAKE' and table_schema in ('ACCOUNT_USAGE', 'ORGANIZATION_USAGE')
                 group by table_name, table_schema
               ), delays as (
             select $1 as table_name, $2 as delay, $3 as ts from (values ('QUERY_HISTORY', 45, 'END_TIME'), ('WAREHOUSE_EVENTS_HISTORY', 180, 'TIMESTAMP'), ('WAREHOUSE_LOAD_HISTORY', 180, 'END_TIME'), ('WAREHOUSE_METERING_HISTORY', 180, 'END_TIME'), ('USERS', 120, 'CREATED_ON'), ('SERVERLESS_TASK_HISTORY', 180, 'END_TIME'))


### PR DESCRIPTION
this fixes the bug introduced in https://github.com/sundeck-io/OpsCenter/pull/243 and reverted in #255. The bug was
related to migrating views but not the underlying tables. In finalize
setup we make sure both tables and views are in sync once we get
permission to access snowflake account usage tables.

closes https://github.com/sundeck-io/OpsCenter/issues/254