### PR TITLE
Make venv unique per job

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -28,11 +28,13 @@ jobs:
         with:
           python-version: '3.8'
           cache: 'pip'
-      - name: install dependencies
+      - name: Install all dependencies
         run: |
           pip install poetry
-          poetry install --with=dev
-          poetry show
+          poetry config virtualenvs.in-project true
+          poetry install
+      - name: Show dependencies
+        run: poetry show
       - name: Make unique names for this job
         id: shell-command
         run: |
@@ -70,7 +72,10 @@ jobs:
       - name: install dependencies
         run: |
           pip install poetry
+          poetry config virtualenvs.in-project true
           poetry install
+      - name: Describe installation
+        run: poetry show
       - name: Get suffix
         id: shell-command
         run:


### PR DESCRIPTION
I think each job is re-using the same venv which confuses poetry into thinking that everything is already installed and ready to go. Try to separate venvs into the checkout for now. Can optimize for github caching later (and modify the script to `poetry update` or whatever is required)

Hunch from https://joaodlf.com/using-poetry-in-github-actions-the-easy-way and noticing that we got the same venv across `unit-tests` and `test-deploy`