### PR TITLE
Fix mis-ordered columns between internal views and staging table

### DIFF
--- a/bootstrap/005_table_migrations.sql
+++ b/bootstrap/005_table_migrations.sql
@@ -25,6 +25,54 @@ BEGIN
       RAISE TABLE_NOT_EXISTS;
   END IF;
 
+  let ctas_query string := '';
+  let alter_query string := '';
+  begin
+      -- Are the list of columns+datatype for the view and table the same?
+      let has_missing_columns boolean := (select count(*) > 0 from (
+          select column_name, data_type from information_schema.columns where table_schema = :view_schema and table_name = :view_name
+          minus
+          select column_name, data_type from information_schema.columns where table_schema = :table_schema and table_name = :table_name
+      ));
+      -- Are the list of columns+datatype+ordinal_position for the view and table the same?
+      let has_misordered_columns boolean := (select count(*) > 0 from (
+          select column_name, data_type, ordinal_position from information_schema.columns where table_schema = :view_schema and table_name = :view_name
+          minus
+          select column_name, data_type, ordinal_position from information_schema.columns where table_schema = :table_schema and table_name = :table_name
+      ));
+
+      -- In the unlikely event that the app has materialized the table with columns in the wrong order (as defined by ORDINAL_POSITION on the view) due
+      -- to an earlier bug in OpsCenter, we need to recreate the tables in order for this migration logic to continue to function in the future. Snowflake
+      -- does not support column reordering, so rewriting the data is the only other alternative that doesn't introduce long-term debt.
+      if (:has_misordered_columns AND not :has_missing_columns) THEN
+          let column_spec string := (select internal.generate_column_def(:view_schema, :view_name));
+          let view_columns string := (select internal.generate_column_names(:view_schema, :view_name));
+          let swap_table_name string := :table_name || '_SWAP';
+
+          begin
+              begin transaction;
+              execute immediate 'DROP TABLE IF EXISTS "' || :table_schema || '"."' || :swap_table_name || '"';
+              -- CREATE TABLE "$schema"."$table_SWAP"($cols) AS SELECT $cols FROM "$schema"."$table"
+              ctas_query := 'CREATE TABLE "' || :table_schema || '"."' || :swap_table_name || '" ( ' || :column_spec || ') AS SELECT ' || :view_columns || ' FROM "' || :table_schema || '"."' || :table_name || '"';
+              execute immediate :ctas_query;
+              -- ALTER TABLE "$schema"."$table" SWAP WITH "$schema"."$table_SWAP"
+              alter_query := 'ALTER TABLE "' || :table_schema || '"."' || :table_name || '" SWAP WITH "' || :table_schema || '"."' || :swap_table_name || '"';
+              execute immediate :alter_query;
+              -- DROP TABLE "$schema"."$table_SWAP"
+              execute immediate 'DROP TABLE "' || :table_schema || '"."' || :swap_table_name || '"';
+              commit;
+          exception
+            when other then
+              SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Failed to migrate misordered table via swap', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
+              ROLLBACK;
+              RAISE;
+          end;
+
+          SYSTEM$LOG_INFO('Table swap executed for ' || :view_schema || '.' || :view_name || ' and ' || :table_schema || '.' || :table_name);
+          SYSTEM$ADD_EVENT('table swap migration', {'ctas_query': :ctas_query, 'alter_query': :alter_query });
+      end if;
+  end;
+
   -- Super important that the columns to add are consistently generated, else we may generate conflicting schemas between two tables created from the same view (the internal_reporting_mv query history tables)
   let columns_to_add string := (
       SELECT LISTAGG('"' || COLUMN_NAME || '" ' || DATA_TYPE, ', ') WITHIN GROUP (ORDER BY ORDINAL_POSITION)
@@ -66,7 +114,9 @@ BEGIN
   if (columns_to_add <> '' OR columns_to_drop <> '') then
       SYSTEM$LOG_INFO('Migration executed for ' || :view_schema || '.' || :view_name || ' and ' || :table_schema || '.' || :table_name);
       SYSTEM$ADD_EVENT('table altered', {'alter_statement': alter_statement || alter_table_add_column || alter_table_drop_column });
-      RETURN alter_table_add_column || alter_table_drop_column;
+      let ctas_msg string := ' CTAS from swap migration ' || ctas_query;
+      let alter_msg string := ' ALTER from swap migration ' || alter_query;
+      RETURN alter_table_add_column || alter_table_drop_column || ctas_msg || alter_msg;
   else
     SYSTEM$LOG_INFO('No migration need for ' || :view_schema || '.' || :view_name || ' and ' || :table_schema || '.' || :table_name);
     RETURN null;
@@ -88,8 +138,20 @@ BEGIN
     return 'Success';
 END;
 
+create or replace function internal.generate_column_def(source_schema varchar, source_table varchar)
+returns string
+as
+$$
+      -- Ordering the LISTAGG by ORDINAL_POSITION is not strictly necessary, but should eliminate confusion when LISTAGG would
+      -- otherwise generate a random ordering of columns each time it is called.
+      SELECT LISTAGG('"' || COLUMN_NAME || '" ' || DATA_TYPE, ', ') WITHIN GROUP (ORDER BY ORDINAL_POSITION)
+      FROM (
+      SELECT COLUMN_NAME, DATA_TYPE, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = source_schema AND TABLE_NAME = source_table
+      )
+$$;
 
-create or replace function internal.generate_column_list(source_schema varchar, source_table varchar)
+
+create or replace function internal.generate_column_names(source_schema varchar, source_table varchar)
 returns string
 as
 $$
@@ -107,7 +169,7 @@ returns string
 as
 $$
 begin
-  let columns string := (select internal.generate_column_list(:source_schema, :source_table));
+  let columns string := (select internal.generate_column_names(:source_schema, :source_table));
 
   let stmt string := 'INSERT INTO "' || :target_schema || '"."' || :target_table || '" (' || columns || ') SELECT ' || columns || ' FROM "' || :source_schema || '"."' || :source_table || '" where ' || :where_clause || ';';
   return :stmt;

--- a/bootstrap/019_query_history_updates.sql
+++ b/bootstrap/019_query_history_updates.sql
@@ -7,7 +7,7 @@ language sql
 as
 begin
     SYSTEM$LOG_TRACE('Migrating query history data.');
-    -- Create internal_reporting views to detect any updates from snowflake
+    -- Update the internal_reporting views to reflect any updates from snowflake's views.
     call internal.migrate_view();
     let migrate1 string := '';
     call internal.migrate_if_necessary('INTERNAL_REPORTING', 'QUERY_HISTORY_COMPLETE_AND_DAILY', 'INTERNAL_REPORTING_MV', 'QUERY_HISTORY_COMPLETE_AND_DAILY') into :migrate1;


### PR DESCRIPTION
This ensures that the column ordering on the materialization QH table is in the order as the account_usage.query_history view. It would be better to enumerate all columns (rather than try to retain ordering), but also a much larger change.

rel #263