### PR TITLE
Defer label view re-creation until after label table migration

### DIFF
--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -32,6 +32,14 @@ BEGIN
             END FOR;
         END;
     END;
+
+-- Migrate the schema of internal tables
+call INTERNAL.MIGRATE_PROBES_TABLE();
+call INTERNAL.MIGRATE_LABELS_TABLE();
+call INTERNAL.MIGRATE_PREDEFINED_PROBES_TABLE();
+call INTERNAL.MIGRATE_PREDEFINED_LABELS_TABLE();
+
+-- Re-generate the internal and public views
 call internal.migrate_queries();
 call internal.migrate_warehouse_events();
 call internal.migrate_view();
@@ -66,16 +74,6 @@ CREATE OR REPLACE TASK TASKS.SFUSER_MAINTENANCE
 -- enable the query_hash column in the query_history view
 call INTERNAL.ENABLE_QUERY_HASH();
 
--- Migrate the schema of the probes table if it already exists
-call INTERNAL.MIGRATE_PROBES_TABLE();
-call INTERNAL.MIGRATE_LABELS_TABLE();
-
--- Migrate the schema of the predefined_probes table if it already exists
-call INTERNAL.MIGRATE_PREDEFINED_PROBES_TABLE();
-
--- Migrate the schema of predefined_labels table if it already exists
-call INTERNAL.MIGRATE_PREDEFINED_LABELS_TABLE();
-
 -- Populate the list of predefined labels
 call INTERNAL.POPULATE_PREDEFINED_LABELS();
 
@@ -89,7 +87,6 @@ call INTERNAL.INITIALIZE_LABELS();
 -- after last install/upgrade of APP
 -- parameter 7200 (seconds) is the timestamp difference when a predefined label is regarded as an old one.
 call INTERNAL.MIGRATE_PREDEFINED_LABELS(7200);
-
 
 -- Populate the list of predefined probes
 call INTERNAL.POPULATE_PREDEFINED_PROBES();

--- a/deploy/devdeploy.py
+++ b/deploy/devdeploy.py
@@ -46,13 +46,15 @@ def _copy_opscenter_files(cur, schema: str, stage: str, deployment: str):
 def _finish_local_setup(cur, database: str, schema: str):
     print("Setting up internal state to mimic a set-up app.")
 
+    # Call FINALIZE_SETUP first to perform any migrations, then
+    # the underlying procedures to avoid waiting for async tasks to run.
     cur.execute(
         f"""
     BEGIN
+        call {database}.ADMIN.FINALIZE_SETUP();
         call {database}.internal.refresh_users();
         call {database}.internal.refresh_warehouse_events(true);
         call {database}.internal.refresh_queries(true);
-        call {database}.ADMIN.FINALIZE_SETUP();
     END;
     """
     )


### PR DESCRIPTION
Consolidate all of the logic around labels into one procedure to try to avoid these kinds of problems in the future.

rel #275

The bug was that finalize_setup ultimately calls update_label_view which expected the internal.labels table to have the `is_dynamic` column but the table was not yet migrated.