### PR TITLE
Closes #285: probes tests failure to find element for deletion.

### DIFF
--- a/cypress/e2e/probes.spec.cy.js
+++ b/cypress/e2e/probes.spec.cy.js
@@ -67,7 +67,7 @@ describe("Probes section", () => {
     checkNoErrorOnThePage();
 
     cy.get("span")
-      .contains("Query Probes",{ timeout: 30000 } )
+      .contains("Query Probes", { timeout: 30000 })
       .scrollIntoView()
       .should("be.visible");
     checkNoErrorOnThePage();

--- a/cypress/e2e/probes.spec.cy.js
+++ b/cypress/e2e/probes.spec.cy.js
@@ -45,7 +45,7 @@ describe("Probes section", () => {
     checkNoErrorOnThePage();
 
     cy.get("span")
-      .contains("Query Probes",{ timeout: 30000 } )
+      .contains("Query Probes", { timeout: 30000 })
       .scrollIntoView()
       .should("be.visible");
     checkNoErrorOnThePage();

--- a/cypress/e2e/probes.spec.cy.js
+++ b/cypress/e2e/probes.spec.cy.js
@@ -43,6 +43,13 @@ describe("Probes section", () => {
     );
     buttonClick("Create");
     checkNoErrorOnThePage();
+
+    cy.get("span")
+      .contains("Query Probes",{ timeout: 30000 } )
+      .scrollIntoView()
+      .should("be.visible");
+    checkNoErrorOnThePage();
+
     probeDelete(probe_1);
 
     // Test #4: Fill the form with valid values and save (checkboxes are unchecked)
@@ -58,6 +65,13 @@ describe("Probes section", () => {
     );
     buttonClick("Create");
     checkNoErrorOnThePage();
+
+    cy.get("span")
+      .contains("Query Probes",{ timeout: 30000 } )
+      .scrollIntoView()
+      .should("be.visible");
+    checkNoErrorOnThePage();
+
     probeDelete(probe_2);
 
     // Among other things, "New" button should exist


### PR DESCRIPTION
I was able to reproduce this locally and the problem appeared to be that second probe creation took longer than usual.
So when the test attempted to delete newly created probe, switch to the "Query Probes" tab where were looking for the probe has not loaded yet. Fixed it by waiting for "Query Probes" text to appear on the screen before attempt to delete.

Would like to give it a try before I make a generic function for all the tests (getSpan("Query Probes")).

