### PR TITLE
Fix the race-condition on devdeploy

### DIFF
--- a/bootstrap/027_user_emails.sql
+++ b/bootstrap/027_user_emails.sql
@@ -6,5 +6,6 @@ BEGIN
     BEGIN TRANSACTION;
         truncate table internal.sfusers;
         insert into internal.sfusers select name, email from snowflake.account_usage.users;
+        call internal.set_config('SNOWFLAKE_USER_MAINTENANCE', current_timestamp()::string);
     COMMIT;
 END;

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -64,12 +64,7 @@ CREATE OR REPLACE TASK TASKS.SFUSER_MAINTENANCE
     ALLOW_OVERLAPPING_EXECUTION = FALSE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "XSMALL"
     AS
-    BEGIN
-        BEGIN TRANSACTION;
-        truncate table internal.sfusers;
-        insert into internal.sfusers select name, email from snowflake.account_usage.users;
-        COMMIT;
-    END;
+    CALL INTERNAL.refresh_users();
 
 -- enable the query_hash column in the query_history view
 call INTERNAL.ENABLE_QUERY_HASH();

--- a/deploy/devdeploy.py
+++ b/deploy/devdeploy.py
@@ -46,31 +46,22 @@ def _copy_opscenter_files(cur, schema: str, stage: str, deployment: str):
 def _finish_local_setup(cur, database: str, schema: str):
     print("Setting up internal state to mimic a set-up app.")
 
-    # Call FINALIZE_SETUP first to perform any migrations, then
-    # the underlying procedures to avoid waiting for async tasks to run.
-    cur.execute(
-        f"""
-    BEGIN
-        call {database}.ADMIN.FINALIZE_SETUP();
-        call {database}.internal.refresh_users();
-        call {database}.internal.refresh_warehouse_events(true);
-        call {database}.internal.refresh_queries(true);
-    END;
-    """
-    )
+    # Call FINALIZE_SETUP first to perform any migrations. This implicitly triggers the tasks.
+    cur.execute(f"call {database}.ADMIN.FINALIZE_SETUP();")
 
     start_time = time.time()
 
+    # Then, wait for the tasks to report that they have run.
     while True:
         # Execute a query to fetch data from the table
         cur.execute(
-            "SELECT * FROM internal.config where key in ('WAREHOUSE_EVENTS_MAINTENANCE', 'QUERY_HISTORY_MAINTENANCE') and value is not null;"
+            "SELECT * FROM internal.config where key in ('WAREHOUSE_EVENTS_MAINTENANCE', 'QUERY_HISTORY_MAINTENANCE', 'SNOWFLAKE_USER_MAINTENANCE') and value is not null;"
         )
 
         rows = cur.fetchall()
 
         # if we have two rows, means materialization is complete
-        if len(rows) == 2:
+        if len(rows) == 3:
             print("OpsCenter setup complete.")
             break
 


### PR DESCRIPTION
Since making the change in 6ed8d218d33990196bf7d15f04b21a97176c275c, I've started noticing some errors (~10% of the time) where `refresh_queries()` or `refresh_warehouse_events()` procedures would throw an "object already exists" error on the staging table. I eventually realized it was due to me manually running the materialization procedure and the task running that procedure conflicting. I'm surprised that the transaction inside the procedure doesn't give us isolation, but will chalk that up to my lack of understanding.

Add a simple "last time completed" row into internal.config for sfuser_maintanence and check for that in devdeploy.py admin.finalize_setup() is already triggered the tasks for us and devdeploy.py is waiting for them. We can skip re-triggered them.