### PR TITLE
288: Fix checkForLoading to account for three possible loading states

### DIFF
--- a/cypress/e2e/queries.spec.cy.js
+++ b/cypress/e2e/queries.spec.cy.js
@@ -54,11 +54,9 @@ describe("Queries section", () => {
 
     dropDownOpen("Select Report");
     dropDownElementClick("dbt Summary");
-    checkNoErrorOnThePage();
 
     dropDownOpen("Pick View");
     dropDownElementClick("List");
-    checkNoErrorOnThePage();
 
     // Iterate over filters
 
@@ -91,6 +89,8 @@ describe("Queries section", () => {
       "Execution Status",
     ];
     for (const category of categorylList) {
+      checkForLoading();
+
       dropDownOpen("Color by Category or Grouping Label");
       dropDownElementClick(category);
 
@@ -106,9 +106,12 @@ describe("Queries section", () => {
 
     const stringList = ["365", "90", "30", "7"];
 
-    cy.get("span").contains("Query Activity").should("be.visible");
+    cy.get("span")
+      .contains("Query Activity", { timeout: 40000 })
+      .should("be.visible");
 
     // Click on Filters
+    cy.log("Click on Filters");
     clickCheck({
       clickElem: 'div[data-testid="stMarkdownContainer"]',
       contains: "Filters",

--- a/cypress/e2e/settings.spec.cy.js
+++ b/cypress/e2e/settings.spec.cy.js
@@ -1,11 +1,12 @@
-import { checkNoErrorOnThePage,
-         checkSuccessAlert,
-         fillInTheSettingsConfigForm,
-         buttonOnTabClick,
-         buttonClick,
-         checkForLoading,
-         clickCheck,
-         setup,
+import {
+  checkNoErrorOnThePage,
+  checkSuccessAlert,
+  fillInTheSettingsConfigForm,
+  buttonOnTabClick,
+  buttonClick,
+  checkForLoading,
+  clickCheck,
+  setup,
 } from "../support/utils";
 
 describe("Settings section", () => {
@@ -18,19 +19,18 @@ describe("Settings section", () => {
   });
 
   it("Menu: Settings. Tab: Config. Validate that we can set and save credits values.", () => {
-
     cy.visit("/");
     checkForLoading();
 
     clickCheck({ clickElem: "span", contains: "Settings" });
 
     clickCheck({ clickElem: 'button[role="tab"]', contains: "Config" });
-    fillInTheSettingsConfigForm(10.00, 20.00, 30.00);
+    fillInTheSettingsConfigForm(10.0, 20.0, 30.0);
     buttonOnTabClick("Save");
     checkSuccessAlert("Saved");
   });
 
-  it("Menu: Settings. Tab: Reset. Validate that we can click 'Reload' button and no exception is thrown .", () => {
+  it.only("Menu: Settings. Tab: Reset. Validate that we can click 'Reload' button and no exception is thrown .", () => {
     cy.visit("/");
     checkForLoading();
 
@@ -45,16 +45,13 @@ describe("Settings section", () => {
 
   describe("Menu: Settings. Tab: Initial Setup", () => {
     it.skip("First step should be marked as completed", () => {
-      cy.get("span")
-        .contains("Settings")
-        .should("be.visible")
-        .click();
+      cy.get("span").contains("Settings").should("be.visible").click();
 
       cy.get('button[role="tab"]')
         .should("exist")
         .contains("Initial Setup")
         .should("exist")
-        .click()
+        .click();
 
       cy.get("p")
         .contains("Step 1: Grant Snowflake Privileges [Completed]")
@@ -62,23 +59,22 @@ describe("Settings section", () => {
     });
 
     it.skip("Sundeck link should be present and contain correct information", () => {
-      cy.get("span")
-        .contains("Settings")
-        .should("be.visible")
-        .click();
+      cy.get("span").contains("Settings").should("be.visible").click();
 
       cy.get('button[role="tab"]')
         .should("exist")
         .contains("Initial Setup")
         .should("exist")
-        .click()
+        .click();
 
       cy.get("a")
         .contains("right click here")
         .should("exist")
         .then(($a) => {
           const href = $a.prop("href");
-          expect(href.startsWith("https://sundeck.io/try?source=opscenter&state=")).to.be.true;
+          expect(
+            href.startsWith("https://sundeck.io/try?source=opscenter&state=")
+          ).to.be.true;
 
           const url = new URL(href);
           const state = url.searchParams.get("state");

--- a/cypress/e2e/settings.spec.cy.js
+++ b/cypress/e2e/settings.spec.cy.js
@@ -30,7 +30,7 @@ describe("Settings section", () => {
     checkSuccessAlert("Saved");
   });
 
-  it.only("Menu: Settings. Tab: Reset. Validate that we can click 'Reload' button and no exception is thrown .", () => {
+  it("Menu: Settings. Tab: Reset. Validate that we can click 'Reload' button and no exception is thrown .", () => {
     cy.visit("/");
     checkForLoading();
 
@@ -41,48 +41,5 @@ describe("Settings section", () => {
     checkNoErrorOnThePage();
 
     checkSuccessAlert("Reset Complete.");
-  });
-
-  describe("Menu: Settings. Tab: Initial Setup", () => {
-    it.skip("First step should be marked as completed", () => {
-      cy.get("span").contains("Settings").should("be.visible").click();
-
-      cy.get('button[role="tab"]')
-        .should("exist")
-        .contains("Initial Setup")
-        .should("exist")
-        .click();
-
-      cy.get("p")
-        .contains("Step 1: Grant Snowflake Privileges [Completed]")
-        .should("exist");
-    });
-
-    it.skip("Sundeck link should be present and contain correct information", () => {
-      cy.get("span").contains("Settings").should("be.visible").click();
-
-      cy.get('button[role="tab"]')
-        .should("exist")
-        .contains("Initial Setup")
-        .should("exist")
-        .click();
-
-      cy.get("a")
-        .contains("right click here")
-        .should("exist")
-        .then(($a) => {
-          const href = $a.prop("href");
-          expect(
-            href.startsWith("https://sundeck.io/try?source=opscenter&state=")
-          ).to.be.true;
-
-          const url = new URL(href);
-          const state = url.searchParams.get("state");
-
-          // ensure state includes our snowflake account
-          const payload = JSON.parse(atob(state));
-          expect(payload.sf_account).to.equal(Cypress.env("SNOWFLAKE_ACCOUNT"));
-        });
-    });
   });
 });

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -165,7 +165,6 @@ export const addNewLabelToGroup = (groupName, labelName, condition, rank) => {
     .should("be.visible")
     .as("tabs");
 
-  // cy.get("@tabs").contains(groupName).click();
   clickCheck({ clickElem: "@tabs", contains: groupName });
 
   // Validate that newly created label is found on the page
@@ -187,7 +186,6 @@ export const labelDelete = (groupName, labelName) => {
     .should("be.visible")
     .as("tabs");
 
-  // cy.get("@tabs").contains(groupName).click();
   clickCheck({ clickElem: "@tabs", contains: groupName, forceClick: true });
 
   cy.get('div[data-testid="stHorizontalBlock"]')
@@ -246,17 +244,11 @@ export const dropDownOpen = (dropDownName) => {
     .parents(".row-widget.stSelectbox")
     .should("exist")
     .within(() => {
-      cy.get('div[data-baseweb="select"]').should("exist").click();
+      clickCheck({ clickElem: 'div[data-baseweb="select"]', forceClick: true });
     });
 };
 
 export const dropDownElementClick = (dropDownElementName) => {
-  // cy.get('li[role="option"]')
-  //   .should("exist")
-  //   .contains(dropDownElementName)
-  //   .as(dropDownElementName);
-  // cy.get(`@${dropDownElementName}`).should("exist").click();
-  // checkNoErrorOnThePage();
   clickCheck({ clickElem: 'li[role="option"]', contains: dropDownElementName });
 };
 

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -244,7 +244,7 @@ export const dropDownOpen = (dropDownName) => {
     .parents(".row-widget.stSelectbox")
     .should("exist")
     .within(() => {
-      clickCheck({ clickElem: 'div[data-baseweb="select"]', forceClick: true });
+      cy.get('svg[title="open"]').should("exist").click();
     });
 };
 


### PR DESCRIPTION
1) no loading spinner EVER
2) loading sipper immediately
3) short delay and then a loading spinner

-- disabled the reset test since it was timing out locally without throttling