### PR TITLE
Two more migration fixes

### DIFF
--- a/bootstrap/004_labels.sql
+++ b/bootstrap/004_labels.sql
@@ -379,6 +379,8 @@ CREATE OR REPLACE PROCEDURE INTERNAL.POPULATE_PREDEFINED_LABELS()
     EXECUTE AS OWNER
 AS
 BEGIN
+    begin transaction;
+    truncate table internal.predefined_labels;
     let query_hash_enabled boolean := (select system$BEHAVIOR_CHANGE_BUNDLE_STATUS('2023_06') = 'ENABLED');
     MERGE INTO internal.predefined_labels t
     USING (
@@ -405,6 +407,7 @@ BEGIN
         ("NAME", "GROUP_NAME", "GROUP_RANK", "LABEL_CREATED_AT", "CONDITION", "LABEL_MODIFIED_AT", "IS_DYNAMIC", "ENABLED")
         VALUES (s.name, NULL, NULL,  current_timestamp(), s.condition, current_timestamp(), FALSE, TRUE);
 
+    commit;
     RETURN NULL;
 EXCEPTION
   WHEN OTHER THEN

--- a/bootstrap/004_labels.sql
+++ b/bootstrap/004_labels.sql
@@ -379,8 +379,6 @@ CREATE OR REPLACE PROCEDURE INTERNAL.POPULATE_PREDEFINED_LABELS()
     EXECUTE AS OWNER
 AS
 BEGIN
-    begin transaction;
-    truncate table internal.predefined_labels;
     let query_hash_enabled boolean := (select system$BEHAVIOR_CHANGE_BUNDLE_STATUS('2023_06') = 'ENABLED');
     MERGE INTO internal.predefined_labels t
     USING (
@@ -407,7 +405,6 @@ BEGIN
         ("NAME", "GROUP_NAME", "GROUP_RANK", "LABEL_CREATED_AT", "CONDITION", "LABEL_MODIFIED_AT", "IS_DYNAMIC", "ENABLED")
         VALUES (s.name, NULL, NULL,  current_timestamp(), s.condition, current_timestamp(), FALSE, TRUE);
 
-    commit;
     RETURN NULL;
 EXCEPTION
   WHEN OTHER THEN

--- a/bootstrap/019_query_history_updates.sql
+++ b/bootstrap/019_query_history_updates.sql
@@ -7,8 +7,8 @@ language sql
 as
 begin
     SYSTEM$LOG_TRACE('Migrating query history data.');
-    -- Update the internal_reporting views to reflect any updates from snowflake's views.
-    call internal.migrate_view();
+    -- Update _only_ the internal_reporting views to reflect any updates from snowflake's views.
+    call INTERNAL.create_view_QUERY_HISTORY_COMPLETE_AND_DAILY();
     let migrate1 string := '';
     call internal.migrate_if_necessary('INTERNAL_REPORTING', 'QUERY_HISTORY_COMPLETE_AND_DAILY', 'INTERNAL_REPORTING_MV', 'QUERY_HISTORY_COMPLETE_AND_DAILY') into :migrate1;
     let migrate2 string := '';

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -66,7 +66,7 @@ CREATE OR REPLACE TASK TASKS.SFUSER_MAINTENANCE
     AS
     CALL INTERNAL.refresh_users();
 
--- enable the query_hash column in the query_history view
+-- create the query_hash functions in TOOLS
 call INTERNAL.ENABLE_QUERY_HASH();
 
 -- Populate the list of predefined labels


### PR DESCRIPTION
1. Truncate the predefined_labels table before we re-define the predefined labels.
2. Don't recreate reporting views before MV migration

Doing an upgrade test now.