### PR TITLE
Reduce area between rows of probes

### DIFF
--- a/app/ui/probes.py
+++ b/app/ui/probes.py
@@ -93,7 +93,7 @@ class Probe:
             )
 
             columns[3].checkbox(
-                label="cancel query",
+                label="",
                 label_visibility="hidden",
                 value=row["CANCEL"],
                 disabled=True,


### PR DESCRIPTION
Weird interaction with Streamlit, the `div` wants to show the label even though its default hidden.

Before:
![20230914-135516](https://github.com/sundeck-io/OpsCenter/assets/2022305/5932f3bb-078e-4840-bf69-dbde4c5c3560)

After:
![20230914-135504](https://github.com/sundeck-io/OpsCenter/assets/2022305/9e0d786f-ffdc-47cd-8106-8e598cddc6cc)

