### PR TITLE
Disable gatherUsageStats and runner.fastReruns

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: run deploy
         run: "poetry run python deploy/devdeploy.py -p opscenter"
       - name: run streamlit
-        run: "poetry run streamlit run app/ui/Home.py &"
+        run: "poetry run streamlit run app/ui/Home.py --browser.gatherUsageStats false --runner.fastReruns false &"
       - name: Set cypress env variables
         run: |
           echo "CYPRESS_SNOWFLAKE_ACCOUNT=${{ secrets.SNOWFLAKE_ACCOUNT }}" >> $GITHUB_ENV

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -115,7 +115,7 @@ jobs:
           mkdir $HOME/.snowsql
           envsubst < deploy/opscenter.config > $HOME/.snowsql/config
       - name: run streamlit
-        run: "poetry run streamlit run app/ui/Home.py &"
+        run: "poetry run streamlit run app/ui/Home.py --browser.gatherUsageStats false --runner.fastReruns false &"
       - name: Set cypress env variables
         run: |
           echo "CYPRESS_SNOWFLAKE_ACCOUNT=${{ secrets.SNOWFLAKE_ACCOUNT }}" >> $GITHUB_ENV


### PR DESCRIPTION
The first one will remove all of the api.segment.io calls in the cypress output and the second one turns off that fun feature where Streamlit will allow navigation to a new page while the current one is still loading.