### PR TITLE
Re-create the query_hash functions before we run tickle query_history…

### DIFF
--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -39,6 +39,13 @@ call INTERNAL.MIGRATE_LABELS_TABLE();
 call INTERNAL.MIGRATE_PREDEFINED_PROBES_TABLE();
 call INTERNAL.MIGRATE_PREDEFINED_LABELS_TABLE();
 
+-- Create all objects which are required by labels before
+-- we try to migrate/run query history.
+--
+-- When an upgrade happens, the query_hash functions would not yet exist
+-- which would break materializations and the view re-creation.
+call INTERNAL.ENABLE_QUERY_HASH();
+
 -- Re-generate the internal and public views
 call internal.migrate_queries();
 call internal.migrate_warehouse_events();
@@ -65,9 +72,6 @@ CREATE OR REPLACE TASK TASKS.SFUSER_MAINTENANCE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "XSMALL"
     AS
     CALL INTERNAL.refresh_users();
-
--- create the query_hash functions in TOOLS
-call INTERNAL.ENABLE_QUERY_HASH();
 
 -- Populate the list of predefined labels
 call INTERNAL.POPULATE_PREDEFINED_LABELS();


### PR DESCRIPTION
… materialization

In testing the next release, @robertmaybin stumbled onto a bug around more mis-ordering in finalize_setup()

* At/after 1.22, we have predefined labels which are created for a user which reference UDFs that OpsCenter creates in the TOOLS schema (when the change bundle that contains query_hash has been enabled for teh account)
* I pre-released 1.23 to fix a bug
* Opening opscenter on v1.23 shows an error on the home page that the query_hash functions in TOOLS are not missing

The reason for this has to do with how Snowflake is executing the upgrades on native apps (and handling rollbacks). The internal.labels table is preserved across releases but the rest of the objects are not. When `admin.finalize_setup()` runs on loading the main page with v1.23, we have labels defined (from v1.22) that reference the TOOLS UDFs, but _they do not yet exist in v1.23_.

Quick fix is to just move the procedure which creates these "earlier" in the script. Long term, I think it would be safer if for UDFs, we always create "dummy" functions in setup.sql and then overwrite with "real" versions in finalize_setup().