### PR TITLE
299: Dechunk and fix probes e2e tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
-          cache: 'pip'
+          python-version: "3.8"
+          cache: "pip"
       - uses: pre-commit/action@v3.0.0
   test-deploy:
     runs-on: ubuntu-latest
@@ -22,8 +22,8 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
-          cache: 'pip'
+          python-version: "3.8"
+          cache: "pip"
       - name: install dependencies
         run: |
           pip install poetry
@@ -57,16 +57,15 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
-          cache: 'pip'
+          python-version: "3.8"
+          cache: "pip"
       - name: install opscenter dependencies
         run: |
           pip install poetry
           poetry install
       - name: Get suffix
         id: shell-command
-        run:
-          echo SUFFIX=$(echo ${GITHUB_HEAD_REF} | sed "s/\./_/g" | sed "s/-/_/g" | sed "s\/\_\g")_${GITHUB_RUN_ID} >> $GITHUB_ENV
+        run: echo SUFFIX=$(echo ${GITHUB_HEAD_REF} | sed "s/\./_/g" | sed "s/-/_/g" | sed "s\/\_\g")_${GITHUB_RUN_ID} >> $GITHUB_ENV
       - name: set config
         env:
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
@@ -84,7 +83,7 @@ jobs:
         run: |
           echo "CYPRESS_SNOWFLAKE_ACCOUNT=${{ secrets.SNOWFLAKE_ACCOUNT }}" >> $GITHUB_ENV
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v6
         with:
           start: yarn run cypress
           browser: chrome

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,8 +12,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
-          cache: 'pip'
+          python-version: "3.8"
+          cache: "pip"
       - uses: pre-commit/action@v3.0.0
   crud-unit-tests:
     runs-on: ubuntu-latest
@@ -24,8 +24,8 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
-          cache: 'pip'
+          python-version: "3.8"
+          cache: "pip"
       - name: Install all dependencies
         run: |
           pip install poetry
@@ -44,8 +44,8 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
-          cache: 'pip'
+          python-version: "3.8"
+          cache: "pip"
       - name: Install all dependencies
         run: |
           pip install poetry
@@ -72,7 +72,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     continue-on-error: true
-    needs: [ devdeploy-with-materialization, cypress-tests ]
+    needs: [devdeploy-with-materialization, cypress-tests]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -80,8 +80,8 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
-          cache: 'pip'
+          python-version: "3.8"
+          cache: "pip"
       - name: Install all dependencies
         run: |
           pip install poetry
@@ -113,8 +113,8 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
-          cache: 'pip'
+          python-version: "3.8"
+          cache: "pip"
       - name: Install all dependencies
         run: |
           pip install poetry
@@ -143,7 +143,7 @@ jobs:
         run: |
           echo "CYPRESS_SNOWFLAKE_ACCOUNT=${{ secrets.SNOWFLAKE_ACCOUNT }}" >> $GITHUB_ENV
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v6
         with:
           start: yarn run cypress
           browser: chrome
@@ -167,8 +167,8 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
-          cache: 'pip'
+          python-version: "3.8"
+          cache: "pip"
       - name: Install all dependencies
         run: |
           pip install poetry
@@ -199,8 +199,8 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
-          cache: 'pip'
+          python-version: "3.8"
+          cache: "pip"
       - name: install dependencies
         run: |
           pip install poetry
@@ -210,8 +210,7 @@ jobs:
         run: poetry show
       - name: Get suffix
         id: shell-command
-        run:
-          echo SUFFIX=$(echo ${GITHUB_HEAD_REF} | sed "s/\./_/g" | sed "s/-/_/g" | sed "s\/\_\g")_${GITHUB_RUN_ID} >> $GITHUB_ENV
+        run: echo SUFFIX=$(echo ${GITHUB_HEAD_REF} | sed "s/\./_/g" | sed "s/-/_/g" | sed "s\/\_\g")_${GITHUB_RUN_ID} >> $GITHUB_ENV
       - name: set config
         env:
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}

--- a/app/ui/probes.py
+++ b/app/ui/probes.py
@@ -271,7 +271,7 @@ class Probe:
                 key="CANCEL", label="Cancel the query", value=update["cancel"]
             )
             st.divider()
-            notify_other = st.text_input(
+            notify_other = st.text_area(
                 key="NOTIFY_OTHER",
                 label="Notify others (comma delimited)",
                 value=update["notify_other"],

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require("cypress");
+const fs = require("fs");
 
 module.exports = defineConfig({
   env: {
@@ -14,6 +15,23 @@ module.exports = defineConfig({
     viewportHeight: 1080,
     viewportWidth: 1920,
     supportFile: "cypress/support/customCypressUtils.ts",
+    video: true,
+    videoCompression: 16,
+    setupNodeEvents(on, config) {
+      // https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
+      on("after:spec", (spec, results) => {
+        if (results && results.video) {
+          // Do we have failures for any retry attempts?
+          const failures = results.tests.some((test) =>
+            test.attempts.some((attempt) => attempt.state === "failed")
+          );
+          if (!failures) {
+            // delete the video if the spec passed and no tests retried
+            fs.unlinkSync(results.video);
+          }
+        }
+      });
+    },
   },
   retries: {
     // Configure retry attempts for `cypress run`

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -2,7 +2,7 @@
 
 ## To install tests cypress on macOS
 
-`yarn install`
+`npm install`
 `poetry run streamlit run app/ui/Home.py`
 
 ## Running all the tests in non-interactive mode

--- a/cypress/e2e/Labels/labels.spec.cy.ts
+++ b/cypress/e2e/Labels/labels.spec.cy.ts
@@ -3,16 +3,16 @@ import { clickCheck } from "../../support/clickUtils";
 import { checkForLoading } from "../../support/loadingUtils";
 import { checkOnCorrectPage } from "../../support/pageAssertionUtils";
 import { setup } from "../../support/setupUtils";
+import {
+  BUTTON_TEXT,
+  HEADER_TEXT,
+  MENU_TEXT,
+} from "../../support/testConstants";
 import { LabelsButtonTests } from "./tests/labelsButtonsTests";
 import { MultipleLabelsCRUDTests } from "./tests/multipleLabelsCRUDTests";
 import { SingleDynamicGroupedLabelCRUDTests } from "./tests/singleDynamicGroupedLabelCRUDTests";
 import { SingleGroupedLabelCRUDTests } from "./tests/singleGroupedLabelCRUDTests";
 import { SingleUngroupedLabelCRUDTests } from "./tests/singleUngroupedLabelCRUDTests";
-import {
-  BUTTON_TEXT,
-  HEADER_TEXT,
-  MENU_TEXT,
-} from "./utilsAndConstants/labelTestConstants";
 
 describe("Labels section", () => {
   before(() => {

--- a/cypress/e2e/Labels/tests/labelsButtonsTests.ts
+++ b/cypress/e2e/Labels/tests/labelsButtonsTests.ts
@@ -1,25 +1,11 @@
-import { checkNoErrorOnThePage } from "../../../support/alertUtils";
-import {
-  clickCheck,
-  buttonClick,
-  buttonCheckExists,
-} from "../../../support/clickUtils";
-import { checkForLoading } from "../../../support/loadingUtils";
+import { buttonClick, buttonCheckExists } from "../../../support/clickUtils";
 import { checkOnCorrectPage } from "../../../support/pageAssertionUtils";
 import { setup } from "../../../support/setupUtils";
-import {
-  BUTTON_TEXT,
-  HEADER_TEXT,
-  MENU_TEXT,
-} from "../utilsAndConstants/labelTestConstants";
+import { BUTTON_TEXT, HEADER_TEXT } from "../../../support/testConstants";
 import { checkPresenceOfGroupNameInput } from "../utilsAndConstants/labelsFormUtils";
 
 export const LabelsButtonTests = () =>
   describe("Label Buttons Tests", () => {
-    before(() => {
-      setup();
-    });
-
     it("Labels Buttons: Validate that New and Cancel buttons work anddon't fail to load the page", () => {
       buttonClick(BUTTON_TEXT.NEW);
       checkOnCorrectPage({ headerText: HEADER_TEXT.CREATE_LABEL });

--- a/cypress/e2e/Labels/tests/multipleLabelsCRUDTests.ts
+++ b/cypress/e2e/Labels/tests/multipleLabelsCRUDTests.ts
@@ -2,16 +2,14 @@ import { checkNoErrorOnThePage } from "../../../support/alertUtils";
 import { buttonClick } from "../../../support/clickUtils";
 import { generateUniqueName } from "../../../support/formUtils";
 import { checkOnCorrectPage } from "../../../support/pageAssertionUtils";
-import { setup } from "../../../support/setupUtils";
+import { HEADER_TEXT, BUTTON_TEXT } from "../../../support/testConstants";
 import {
-  BUTTON_TEXT,
-  HEADER_TEXT,
   QUERY_TEXT_1,
   QUERY_TEXT_2,
   UNGROUPED,
 } from "../utilsAndConstants/labelTestConstants";
+import { fillInNewLabelForm } from "../utilsAndConstants/labelsFormUtils";
 import {
-  fillInNewLabelForm,
   addNewLabelToGroup,
   labelDelete,
   checkLabelExists,
@@ -19,10 +17,6 @@ import {
 
 export const MultipleLabelsCRUDTests = () =>
   describe("Multiple label Creation/Deletion tests", () => {
-    before(() => {
-      setup();
-    });
-
     describe("Able to Create / Delete an ungrouped label with multiple labels", () => {
       const label_1 = generateUniqueName("firstLabel");
       const label_2 = generateUniqueName("secondLabel");

--- a/cypress/e2e/Labels/tests/singleDynamicGroupedLabelCRUDTests.ts
+++ b/cypress/e2e/Labels/tests/singleDynamicGroupedLabelCRUDTests.ts
@@ -1,27 +1,24 @@
 import { buttonClick } from "../../../support/clickUtils";
 import { generateUniqueName } from "../../../support/formUtils";
-import { setup } from "../../../support/setupUtils";
+import { clickUpdateActionButton } from "../../../support/listingPageUtils";
+import { BUTTON_TEXT } from "../../../support/testConstants";
 import {
-  BUTTON_TEXT,
   DYNAMIC_GROUPED_LABEL_QUERY_TEXT_1,
   DYNAMIC_GROUPED_LABEL_QUERY_TEXT_2,
   LABEL_TYPES,
 } from "../utilsAndConstants/labelTestConstants";
 import {
+  checkLabelFormValues,
+  updateLabelForm,
+} from "../utilsAndConstants/labelsFormUtils";
+import {
   createNewLabel,
   deleteLabel,
-  labelUpdateClick,
-  updateLabelForm,
-  checkLabelFormValues,
   checkUpdatedLabelExists,
 } from "../utilsAndConstants/labelsUtils";
 
 export const SingleDynamicGroupedLabelCRUDTests = () =>
   describe("Single Dynamic Grouped Label Tests", () => {
-    before(() => {
-      setup();
-    });
-
     describe("Able to Create / Read / Update / Delete", () => {
       const groupName = generateUniqueName("initialDynamicGroupedCRUD");
 
@@ -34,7 +31,7 @@ export const SingleDynamicGroupedLabelCRUDTests = () =>
       });
 
       it("Read / Update an dynamic grouped label (can fail if previous test in this section failed)", () => {
-        labelUpdateClick({
+        clickUpdateActionButton({
           groupName: groupName,
           condition: DYNAMIC_GROUPED_LABEL_QUERY_TEXT_1,
         });

--- a/cypress/e2e/Labels/tests/singleGroupedLabelCRUDTests.ts
+++ b/cypress/e2e/Labels/tests/singleGroupedLabelCRUDTests.ts
@@ -1,27 +1,24 @@
 import { buttonClick } from "../../../support/clickUtils";
 import { generateUniqueName } from "../../../support/formUtils";
-import { setup } from "../../../support/setupUtils";
+import { clickUpdateActionButton } from "../../../support/listingPageUtils";
+import { BUTTON_TEXT } from "../../../support/testConstants";
 import {
-  BUTTON_TEXT,
   LABEL_TYPES,
   QUERY_TEXT_1,
   QUERY_TEXT_2,
 } from "../utilsAndConstants/labelTestConstants";
 import {
+  checkLabelFormValues,
+  updateLabelForm,
+} from "../utilsAndConstants/labelsFormUtils";
+import {
   createNewLabel,
   deleteLabel,
-  labelUpdateClick,
-  updateLabelForm,
-  checkLabelFormValues,
   checkUpdatedLabelExists,
 } from "../utilsAndConstants/labelsUtils";
 
 export const SingleGroupedLabelCRUDTests = () =>
   describe("Single Grouped Label Tests", () => {
-    before(() => {
-      setup();
-    });
-
     describe("Able to Create / Read / Update/ Delete", () => {
       const label_1 = generateUniqueName("initialGroupedLabelCRUD");
       const label_2 = generateUniqueName("newLabelReadUpdate");
@@ -40,7 +37,7 @@ export const SingleGroupedLabelCRUDTests = () =>
       });
 
       it("Read / Update a grouped label (can fail if previous test in this section failed)", () => {
-        labelUpdateClick({ labelName: label_1, groupName: groupName });
+        clickUpdateActionButton({ name: label_1, groupName: groupName });
 
         checkLabelFormValues({
           labelName: label_1,

--- a/cypress/e2e/Labels/tests/singleUngroupedLabelCRUDTests.ts
+++ b/cypress/e2e/Labels/tests/singleUngroupedLabelCRUDTests.ts
@@ -1,27 +1,25 @@
 import { buttonClick } from "../../../support/clickUtils";
 import { generateUniqueName } from "../../../support/formUtils";
+import { clickUpdateActionButton } from "../../../support/listingPageUtils";
 import { setup } from "../../../support/setupUtils";
+import { BUTTON_TEXT } from "../../../support/testConstants";
 import {
-  BUTTON_TEXT,
   LABEL_TYPES,
   QUERY_TEXT_1,
   QUERY_TEXT_2,
 } from "../utilsAndConstants/labelTestConstants";
 import {
+  checkLabelFormValues,
+  updateLabelForm,
+} from "../utilsAndConstants/labelsFormUtils";
+import {
   createNewLabel,
   deleteLabel,
-  labelUpdateClick,
-  updateLabelForm,
-  checkLabelFormValues,
   checkUpdatedLabelExists,
 } from "../utilsAndConstants/labelsUtils";
 
 export const SingleUngroupedLabelCRUDTests = () =>
   describe("Single Ungrouped Label Tests", () => {
-    before(() => {
-      setup();
-    });
-
     describe("Able to Create / Read / Update / Delete", () => {
       const label_1 = generateUniqueName("initialUnGroupedLabelCRUD");
       const label_2 = generateUniqueName("newLabelCRUD");
@@ -35,7 +33,7 @@ export const SingleUngroupedLabelCRUDTests = () =>
       });
 
       it("Update an ungrouped label (can fail if previous test in this section failed)", () => {
-        labelUpdateClick({ labelName: label_1 });
+        clickUpdateActionButton({ name: label_1 });
         checkLabelFormValues({
           labelName: label_1,
           condition: QUERY_TEXT_1,

--- a/cypress/e2e/Labels/utilsAndConstants/labelTestConstants.ts
+++ b/cypress/e2e/Labels/utilsAndConstants/labelTestConstants.ts
@@ -1,24 +1,5 @@
 export const UNGROUPED = "Ungrouped";
 
-export const BUTTON_TEXT = {
-  CREATE: "Create",
-  UPDATE: "Update",
-  CANCEL: "Cancel",
-  NEW: "New",
-  NEW_GROUPED: "New (in group)",
-  NEW_DYNAMIC_GROUPED: "New dynamic grouped labels",
-};
-
-export const MENU_TEXT = {
-  LABELS: "Labels",
-  HOME: "Home",
-  SETTINGS: "Settings",
-  WAREHOUSES: "Warehouses",
-  QUERIES: "Queries",
-  PROBES: "Probes",
-  LABS: "Labs",
-};
-
 export const LABEL_FORM_FIELDS = {
   LABEL_NAME: "Label Name",
   GROUP_NAME: "Group Name",
@@ -31,13 +12,6 @@ export enum LABEL_TYPES {
   UNGROUPED = "UNGROUPED",
   DYNAMIC_GROUPED = "DYNAMIC_GROUPED",
 }
-
-export const HEADER_TEXT = {
-  LABELS: "Query Labels",
-  HOME: "Welcome To Sundeck OpsCenter",
-  CREATE_LABEL: "New Label",
-  UPDATE_LABEL: "Edit Label",
-};
 
 export const QUERY_TEXT_1 = "compilation_time > 5000";
 export const QUERY_TEXT_2 = "query_type = 'select'";

--- a/cypress/e2e/Labels/utilsAndConstants/labelsFormUtils.ts
+++ b/cypress/e2e/Labels/utilsAndConstants/labelsFormUtils.ts
@@ -1,10 +1,10 @@
-import { LABEL_FORM_FIELDS } from "./labelTestConstants";
+import { LABEL_FORM_FIELDS, UNGROUPED } from "./labelTestConstants";
 
 export const checkPresenceOfGroupNameInput = (options: {
   isPresent: boolean;
 }) => {
   const { isPresent = true } = options;
-  cy.dataId({ value: "stMarkdownContainer" })
+  cy.dataId("stMarkdownContainer")
     .contains(LABEL_FORM_FIELDS.GROUP_NAME)
     .should(($el) => {
       if (isPresent) {
@@ -13,4 +13,71 @@ export const checkPresenceOfGroupNameInput = (options: {
         expect($el).to.not.exist;
       }
     });
+};
+
+export const fillInNewLabelForm = (options: {
+  groupName?: string;
+  labelName?: string;
+  condition: string;
+  rank?: string;
+}) => {
+  const { groupName, labelName, condition, rank } = options;
+
+  labelName && cy.get('input[aria-label="Label Name"]').clear().type(labelName);
+
+  groupName &&
+    groupName !== UNGROUPED &&
+    cy.get('input[aria-label="Group Name"]').clear().type(groupName);
+
+  rank &&
+    cy.get('input[aria-label="Group Rank"]').clear().type(rank).type("{enter}");
+
+  cy.get('textarea[aria-label="Condition"]')
+    .clear()
+    .type(condition)
+    .type("{command+enter}");
+};
+
+export const updateLabelForm = (options: {
+  newLabelName?: string;
+  newCondition?: string;
+  newRank?: string;
+}) => {
+  const { newLabelName, newCondition, newRank } = options;
+
+  newLabelName &&
+    cy
+      .get('input[aria-label="Label Name"]')
+      .clear()
+      .type(newLabelName)
+      .type("{enter}");
+
+  newRank &&
+    cy
+      .get('input[aria-label="Group Rank"]')
+      .clear()
+      .type(newRank)
+      .type("{enter}");
+
+  newCondition &&
+    cy
+      .get('textarea[aria-label="Condition"]')
+      .clear()
+      .type(newCondition)
+      .type("{command+enter}");
+};
+
+export const checkLabelFormValues = (options: {
+  labelName?: string;
+  condition: string;
+  groupName?: string;
+  rank?: string;
+}) => {
+  const { labelName, condition, groupName, rank } = options;
+  labelName &&
+    cy.get('input[aria-label="Label Name"]').should("have.value", labelName);
+  cy.get('textarea[aria-label="Condition"]').should("have.value", condition);
+  groupName &&
+    cy.get('input[aria-label="Group Name"]').should("have.value", groupName);
+  rank && cy.get('input[aria-label="Group Rank"]').should("have.value", rank);
 };

--- a/cypress/e2e/Labels/utilsAndConstants/labelsUtils.ts
+++ b/cypress/e2e/Labels/utilsAndConstants/labelsUtils.ts
@@ -5,52 +5,9 @@ import {
   buttonClick,
 } from "../../../support/clickUtils";
 import { checkOnCorrectPage } from "../../../support/pageAssertionUtils";
-import {
-  BUTTON_TEXT,
-  HEADER_TEXT,
-  LABEL_TYPES,
-  UNGROUPED,
-} from "./labelTestConstants";
-
-export const fillInNewUngroupedLabelForm = (options: {
-  labelName: string;
-  condition: string;
-}) => {
-  const { labelName, condition } = options;
-  if (labelName) {
-    cy.get('input[aria-label="Label Name"]').clear().type(labelName);
-  }
-
-  if (condition) {
-    cy.get('textarea[aria-label="Condition"]')
-      .clear()
-      .type(condition)
-      .type("{command+enter}");
-  }
-};
-
-export const fillInNewLabelForm = (options: {
-  groupName?: string;
-  labelName?: string;
-  condition: string;
-  rank?: string;
-}) => {
-  const { groupName, labelName, condition, rank } = options;
-
-  labelName && cy.get('input[aria-label="Label Name"]').clear().type(labelName);
-
-  groupName &&
-    groupName !== UNGROUPED &&
-    cy.get('input[aria-label="Group Name"]').clear().type(groupName);
-
-  rank &&
-    cy.get('input[aria-label="Group Rank"]').clear().type(rank).type("{enter}");
-
-  cy.get('textarea[aria-label="Condition"]')
-    .clear()
-    .type(condition)
-    .type("{command+enter}");
-};
+import { BUTTON_TEXT, HEADER_TEXT } from "../../../support/testConstants";
+import { LABEL_TYPES, UNGROUPED } from "./labelTestConstants";
+import { fillInNewLabelForm } from "./labelsFormUtils";
 
 export const addNewLabelToGroup = (options: {
   groupName: string;
@@ -155,11 +112,11 @@ export function checkLabelExists(options: {
   });
 
   if (labelName) {
-    cy.dataId({ value: "stMarkdownContainer" })
+    cy.dataId("stMarkdownContainer")
       .contains(labelName)
       .should(doesExist ? "exist" : "not.exist");
   } else if (condition) {
-    cy.dataId({ value: "stVerticalBlock" })
+    cy.dataId("stVerticalBlock")
       .contains(condition)
       .should(doesExist ? "exist" : "not.exist");
   }
@@ -180,28 +137,19 @@ export function checkUpdatedLabelExists(options: {
   });
 
   if (labelName) {
-    cy.dataId({ value: "stHorizontalBlock" })
+    cy.dataId("stHorizontalBlock")
       .should("exist")
       .contains(labelName)
       .parents('div[data-testid="stHorizontalBlock"]') // finds all the parents of the element with labelName
       .should("exist")
       .within(() => {
         condition &&
-          cy
-            .dataId({ value: "stVerticalBlock" })
-            .contains(condition)
-            .should("exist");
+          cy.dataId("stVerticalBlock").contains(condition).should("exist");
 
-        rank &&
-          cy
-            .dataId({ value: "stVerticalBlock" })
-            .contains(rank)
-            .should("exist");
+        rank && cy.dataId("stVerticalBlock").contains(rank).should("exist");
       });
   } else if (condition) {
-    cy.dataId({ value: "stHorizontalBlock" })
-      .should("exist")
-      .contains(condition);
+    cy.dataId("stHorizontalBlock").should("exist").contains(condition);
   }
 }
 
@@ -214,74 +162,6 @@ export const clickLabelGroupTab = (groupName: string) => {
     .as("labelGroupTab");
 
   clickCheck({ clickElem: "@labelGroupTab" });
-};
-
-export const labelUpdateClick = (options: {
-  labelName?: string;
-  condition?: string;
-  groupName?: string;
-}) => {
-  const { labelName, condition, groupName } = options;
-  if (groupName) {
-    clickLabelGroupTab(groupName);
-  }
-  cy.get('div[data-testid="stHorizontalBlock"]')
-    .should("exist")
-    .contains(labelName ? labelName : condition)
-    .should("exist")
-    .parents('div[data-testid="stHorizontalBlock"]') // finds all the parents of the element with labelName
-    .should("exist")
-    .within(() => {
-      // Only searches within specific stHorizontalBlock that has probeName
-      clickCheck({
-        clickElem: 'div[data-testid="column"]',
-        contains: "✏️",
-      });
-    });
-};
-
-export const updateLabelForm = (options: {
-  newLabelName?: string;
-  newCondition?: string;
-  newRank?: string;
-}) => {
-  const { newLabelName, newCondition, newRank } = options;
-
-  newLabelName &&
-    cy
-      .get('input[aria-label="Label Name"]')
-      .clear()
-      .type(newLabelName)
-      .type("{enter}");
-
-  newRank &&
-    cy
-      .get('input[aria-label="Group Rank"]')
-      .clear()
-      .type(newRank)
-      .type("{enter}");
-
-  newCondition &&
-    cy
-      .get('textarea[aria-label="Condition"]')
-      .clear()
-      .type(newCondition)
-      .type("{command+enter}");
-};
-
-export const checkLabelFormValues = (options: {
-  labelName?: string;
-  condition: string;
-  groupName?: string;
-  rank?: string;
-}) => {
-  const { labelName, condition, groupName, rank } = options;
-  labelName &&
-    cy.get('input[aria-label="Label Name"]').should("have.value", labelName);
-  cy.get('textarea[aria-label="Condition"]').should("have.value", condition);
-  groupName &&
-    cy.get('input[aria-label="Group Name"]').should("have.value", groupName);
-  rank && cy.get('input[aria-label="Group Rank"]').should("have.value", rank);
 };
 
 export const createNewLabel = (options: {

--- a/cypress/e2e/Probes/probes.spec.cy.ts
+++ b/cypress/e2e/Probes/probes.spec.cy.ts
@@ -1,83 +1,37 @@
 import { checkNoErrorOnThePage } from "../../support/alertUtils";
-import {
-  clickCheck,
-  buttonClick,
-  buttonCheckExists,
-} from "../../support/clickUtils";
-import { generateUniqueName } from "../../support/formUtils";
+import { clickCheck } from "../../support/clickUtils";
 import { checkForLoading } from "../../support/loadingUtils";
+import { checkOnCorrectPage } from "../../support/pageAssertionUtils";
 import { setup } from "../../support/setupUtils";
 import {
   BUTTON_TEXT,
+  HEADER_TEXT,
   MENU_TEXT,
-} from "../Labels/utilsAndConstants/labelTestConstants";
-import { fillInProbeForm, probeDelete } from "./utils/probesUtils";
+} from "../../support/testConstants";
+import { ProbesButtonTests } from "./tests/probesButtonTests";
+import { ProbesCRUDTests } from "./tests/probesPageTests";
 
-describe("Probes section", () => {
+describe("Labels section", () => {
   before(() => {
     setup();
   });
 
-  it("Menu: Probes", () => {
+  beforeEach(() => {
     cy.visit("/");
 
     checkForLoading();
 
     clickCheck({ clickElem: "span", contains: MENU_TEXT.PROBES });
 
-    cy.get("span").contains("Query Probes").should("be.visible");
-    checkNoErrorOnThePage();
-
-    // Test #1: validate that clicking on "New" button starts page without error
-    buttonClick(BUTTON_TEXT.NEW);
-
-    // Test #2: validate that clicking on "Cancel" brings form back to "New" button
-    buttonClick(BUTTON_TEXT.CANCEL);
-    buttonCheckExists(BUTTON_TEXT.NEW);
-    checkNoErrorOnThePage();
-
-    // Test #3: Fill the form with valid values and save
-    buttonClick(BUTTON_TEXT.NEW);
-    const probe_1 = generateUniqueName("probe");
-    fillInProbeForm({
-      probeName: probe_1,
-      condition: "query_text='%tpch_sf100%'",
-      emailTheAuthor: true,
-      cancelTheQuery: true,
-      emailOthers: "vicky@sundeck.io, jinfeng@sundeck.io",
+    checkOnCorrectPage({
+      headerText: HEADER_TEXT.PROBES,
+      notRightPageText: [HEADER_TEXT.CREATE_PROBE, HEADER_TEXT.UPDATE_PROBE],
+      notRightPageButton: BUTTON_TEXT.CANCEL,
     });
-    buttonClick(BUTTON_TEXT.CREATE);
 
-    cy.get("span")
-      .contains("Query Probes", { timeout: 30000 })
-      .scrollIntoView()
-      .should("be.visible");
     checkNoErrorOnThePage();
-
-    probeDelete(probe_1);
-
-    // Test #4: Fill the form with valid values and save (checkboxes are unchecked)
-    buttonClick(BUTTON_TEXT.NEW);
-    checkNoErrorOnThePage();
-    const probe_2 = generateUniqueName("probe");
-    fillInProbeForm({
-      probeName: probe_2,
-      condition: "query_text='%tpch_sf1%'",
-      emailTheAuthor: false,
-      cancelTheQuery: false,
-      emailOthers: "vicky@sundeck.io, jinfeng@sundeck.io",
-    });
-    buttonClick(BUTTON_TEXT.CREATE);
-
-    cy.get("span")
-      .contains("Query Probes", { timeout: 30000 })
-      .scrollIntoView()
-      .should("be.visible");
-    checkNoErrorOnThePage();
-
-    probeDelete(probe_2);
-
-    // Among other things, "New" button should exist
-    buttonCheckExists(BUTTON_TEXT.NEW);
   });
+
+  ProbesButtonTests();
+  ProbesCRUDTests();
 });

--- a/cypress/e2e/Probes/tests/probesButtonTests.ts
+++ b/cypress/e2e/Probes/tests/probesButtonTests.ts
@@ -1,0 +1,16 @@
+import { buttonClick } from "../../../support/clickUtils";
+import { checkOnCorrectPage } from "../../../support/pageAssertionUtils";
+import { BUTTON_TEXT, HEADER_TEXT } from "../../../support/testConstants";
+
+export const ProbesButtonTests = () => {
+  describe("Probes Button Tests", () => {
+    it("New button takes you to the probes form", () => {
+      buttonClick(BUTTON_TEXT.NEW);
+      checkOnCorrectPage({ headerText: HEADER_TEXT.CREATE_PROBE });
+    });
+    it("Cancel button takes you back from the probes form", () => {
+      buttonClick(BUTTON_TEXT.NEW);
+      checkOnCorrectPage({ headerText: HEADER_TEXT.CREATE_PROBE });
+    });
+  });
+};

--- a/cypress/e2e/Probes/tests/probesPageTests.ts
+++ b/cypress/e2e/Probes/tests/probesPageTests.ts
@@ -1,0 +1,81 @@
+import { buttonClick } from "../../../support/clickUtils";
+import { generateUniqueName } from "../../../support/formUtils";
+import { clickUpdateActionButton } from "../../../support/listingPageUtils";
+import { checkOnCorrectPage } from "../../../support/pageAssertionUtils";
+import { BUTTON_TEXT } from "../../../support/testConstants";
+import {
+  PROBE_CONDITION_TEXT_1,
+  PROBE_CONDITION_TEXT_2,
+  PROBE_EMAIL_OTHERS,
+  PROBE_SLACK_OTHERS,
+} from "../utils/probeTestConstants";
+import {
+  checkProbeFormValues,
+  fillInOrUpdateProbeForm,
+} from "../utils/probesFormUtils";
+import {
+  checkProbeAndValuesExistInProbesList,
+  deleteProbe,
+} from "../utils/probesUtils";
+
+export const ProbesCRUDTests = () => {
+  describe("Single Probe Tests", () => {
+    describe("Able to Create / Read / Update / Delete", () => {
+      const probe_1 = generateUniqueName("probeCRUDTests");
+      const probe_2 = generateUniqueName("updatedProbeCRUDTests");
+
+      it("Create probe", () => {
+        buttonClick(BUTTON_TEXT.NEW);
+        fillInOrUpdateProbeForm({
+          probeName: probe_1,
+          condition: PROBE_CONDITION_TEXT_1,
+          notifyTheAuthor: true,
+          cancelTheQuery: true,
+          notifyOthers: PROBE_EMAIL_OTHERS,
+        });
+        buttonClick(BUTTON_TEXT.CREATE);
+        checkOnCorrectPage({ headerText: "Query Probes" });
+        checkProbeAndValuesExistInProbesList({
+          doesExist: true,
+          probeName: probe_1,
+          condition: PROBE_CONDITION_TEXT_1,
+          notifyTheAuthor: true,
+          cancelTheQuery: true,
+          notifyOthers: PROBE_EMAIL_OTHERS,
+        });
+      });
+
+      it("Read / Update probe", () => {
+        clickUpdateActionButton({ name: probe_1 });
+        checkProbeFormValues({
+          probeName: probe_1,
+          condition: PROBE_CONDITION_TEXT_1,
+          notifyTheAuthor: true,
+          cancelTheQuery: true,
+          notifyOthers: PROBE_EMAIL_OTHERS,
+        });
+        fillInOrUpdateProbeForm({
+          probeName: probe_2,
+          condition: PROBE_CONDITION_TEXT_2,
+          notifyTheAuthor: true,
+          cancelTheQuery: true,
+          notifyOthers: PROBE_SLACK_OTHERS,
+        });
+        buttonClick(BUTTON_TEXT.UPDATE);
+        checkOnCorrectPage({ headerText: "Query Probes" });
+        checkProbeAndValuesExistInProbesList({
+          doesExist: true,
+          probeName: probe_2,
+          condition: PROBE_CONDITION_TEXT_2,
+          notifyTheAuthor: false,
+          cancelTheQuery: false,
+          notifyOthers: PROBE_SLACK_OTHERS,
+        });
+      });
+
+      it("Delete probe", () => {
+        deleteProbe([probe_1, probe_2]);
+      });
+    });
+  });
+};

--- a/cypress/e2e/Probes/utils/probeTestConstants.ts
+++ b/cypress/e2e/Probes/utils/probeTestConstants.ts
@@ -1,0 +1,16 @@
+export const PROBE_FORM_FIELDS = {
+  PROBE_NAME: "Probe Name",
+  CONDITION: "Condition",
+  NOTIFY_AUTHOR: "Notify the author",
+  EMAIL: "Email",
+  SLACK: "Slack",
+  CANCEL_THE_QUERY: "Cancel the query",
+  NOTIFY_OTHERS: "Notify others (comma delimited)",
+};
+
+export const PROBE_CONDITION_TEXT_1 = "query_text='%tpch_sf100%'";
+export const PROBE_CONDITION_TEXT_2 = "query_text='%tpch_sf50%'";
+export const PROBE_EMAIL_OTHERS = "vicky@sundeck.io, jinfeng@sundeck.io";
+export const PROBE_SLACK_OTHERS = "susannah";
+
+export const PROBE_DELETED_NOTIFICATION_TEXT = "Probe deleted";

--- a/cypress/e2e/Probes/utils/probesFormUtils.ts
+++ b/cypress/e2e/Probes/utils/probesFormUtils.ts
@@ -1,0 +1,102 @@
+import { PROBE_FORM_FIELDS } from "./probeTestConstants";
+
+export const fillInOrUpdateProbeForm = (options: {
+  probeName?: string;
+  condition?: string;
+  notifyTheAuthor?: boolean;
+  cancelTheQuery?: boolean;
+  notifyOthers?: string;
+}) => {
+  const {
+    probeName,
+    condition,
+    notifyTheAuthor,
+    cancelTheQuery,
+    notifyOthers,
+  } = options;
+
+  probeName &&
+    cy
+      .get(`input[aria-label="${PROBE_FORM_FIELDS.PROBE_NAME}"]`)
+      .clear()
+      .type(probeName);
+
+  condition &&
+    cy
+      .get(`textarea[aria-label="${PROBE_FORM_FIELDS.CONDITION}"]`)
+      .clear()
+      .type(condition);
+
+  // check({force: true}) - explanation below
+  // https://docs.cypress.io/guides/references/error-messages#cy-failed-because-the-element-cannot-be-interacted-with
+  notifyTheAuthor !== undefined &&
+    cy
+      .get(`input[aria-label="${PROBE_FORM_FIELDS.NOTIFY_AUTHOR}"]`)
+      .should("exist")
+      .click({ force: true });
+
+  cancelTheQuery !== undefined &&
+    cy
+      .get(`input[aria-label="${PROBE_FORM_FIELDS.CANCEL_THE_QUERY}"]`)
+      .should("exist")
+      .click({ force: true });
+
+  notifyOthers &&
+    cy
+      .get(`textarea[aria-label="${PROBE_FORM_FIELDS.NOTIFY_OTHERS}"]`)
+      .clear()
+      .type(notifyOthers)
+      .type("{command+enter}");
+};
+
+export const checkProbeFormValues = (options: {
+  probeName?: string;
+  condition?: string;
+  notifyTheAuthor?: boolean;
+  cancelTheQuery?: boolean;
+  notifyOthers?: string;
+}) => {
+  const {
+    probeName,
+    condition,
+    notifyTheAuthor,
+    cancelTheQuery,
+    notifyOthers,
+  } = options;
+
+  probeName &&
+    cy
+      .get(`input[aria-label="${PROBE_FORM_FIELDS.PROBE_NAME}"]`)
+      .should("exist")
+      .should("have.value", probeName);
+
+  condition &&
+    cy
+      .get(`textarea[aria-label="${PROBE_FORM_FIELDS.CONDITION}"]`)
+      .should("exist")
+      .should("have.value", condition);
+
+  notifyTheAuthor !== undefined &&
+    cy
+      .get(
+        `input[aria-label="${PROBE_FORM_FIELDS.NOTIFY_AUTHOR}"][aria-checked="${
+          notifyTheAuthor ? true : false
+        }"]`
+      )
+      .should("exist");
+
+  cancelTheQuery !== undefined &&
+    cy
+      .get(
+        `input[aria-label="${
+          PROBE_FORM_FIELDS.CANCEL_THE_QUERY
+        }"][aria-checked="${cancelTheQuery ? true : false}"]`
+      )
+      .should("exist");
+
+  notifyOthers &&
+    cy
+      .get(`textarea[aria-label="${PROBE_FORM_FIELDS.NOTIFY_OTHERS}"]`)
+      .should("exist")
+      .should("have.value", notifyOthers);
+};

--- a/cypress/e2e/Queries/queries.spec.cy.ts
+++ b/cypress/e2e/Queries/queries.spec.cy.ts
@@ -2,7 +2,7 @@ import { clickCheck, dropDownElementClick } from "../../support/clickUtils";
 import { dropDownOpen } from "../../support/formUtils";
 import { checkForLoading } from "../../support/loadingUtils";
 import { setup } from "../../support/setupUtils";
-import { MENU_TEXT } from "../Labels/utilsAndConstants/labelTestConstants";
+import { MENU_TEXT } from "../../support/testConstants";
 
 describe("Queries section", () => {
   before(() => {

--- a/cypress/e2e/Settings/settings.spec.cy.ts
+++ b/cypress/e2e/Settings/settings.spec.cy.ts
@@ -10,7 +10,7 @@ import {
 } from "../../support/clickUtils";
 import { checkForLoading } from "../../support/loadingUtils";
 import { fillInTheSettingsConfigForm } from "./utils/settingsUtils";
-import { MENU_TEXT } from "../Labels/utilsAndConstants/labelTestConstants";
+import { MENU_TEXT } from "../../support/testConstants";
 
 describe("Settings section", () => {
   before(() => {

--- a/cypress/e2e/Warehouses/warehouse.spec.cy.ts
+++ b/cypress/e2e/Warehouses/warehouse.spec.cy.ts
@@ -1,7 +1,7 @@
 import { clickCheck } from "../../support/clickUtils";
 import { checkForLoading } from "../../support/loadingUtils";
 import { setup } from "../../support/setupUtils";
-import { MENU_TEXT } from "../Labels/utilsAndConstants/labelTestConstants";
+import { MENU_TEXT } from "../../support/testConstants";
 
 describe("Warehouse section", () => {
   before(() => {

--- a/cypress/support/alertUtils.ts
+++ b/cypress/support/alertUtils.ts
@@ -33,7 +33,9 @@ export function checkNoErrorOnThePage() {
 export function checkSuccessAlert(notificationText: string) {
   cy.get('div[role="alert"][data-baseweb="notification"]', {
     timeout: 60000,
-  }).and("contain", notificationText);
+  })
+    .and("contain", notificationText)
+    .should("exist");
 }
 
 // Check for failure notification with particular text presence

--- a/cypress/support/customCypressUtils.ts
+++ b/cypress/support/customCypressUtils.ts
@@ -7,32 +7,27 @@ declare global {
        * Custom command to select DOM element by data-cy attribute.
        * @example cy.dataCy('greeting')
        */
-      dataCy(options: {
-        value: string;
-        timeout?: number;
-      }): Chainable<JQuery<HTMLElement>>;
-      dataId(options: {
-        value: string;
-        timeout?: number;
-      }): Chainable<JQuery<HTMLElement>>;
+      dataCy(value: string, timeout?: number): Chainable<JQuery<HTMLElement>>;
+      dataId(value: string, timeout?: number): Chainable<JQuery<HTMLElement>>;
+      dataBW(value: string, timeout?: number): Chainable<JQuery<HTMLElement>>;
     }
   }
 }
 
-Cypress.Commands.add(
-  "dataCy",
-  (options: { value: string; timeout?: number }) => {
-    return cy.get(`[data-cy=${options.value}]`, {
-      timeout: options.timeout ? options.timeout : 10000,
-    });
-  }
-);
+Cypress.Commands.add("dataCy", (value, timeout) => {
+  return cy.get(`[data-cy=${value}]`, {
+    timeout: timeout ? timeout : 10000,
+  });
+});
 
-Cypress.Commands.add(
-  "dataId",
-  (options: { value: string; timeout?: number }) => {
-    return cy.get(`[data-testid=${options.value}]`, {
-      timeout: options.timeout ? options.timeout : 10000,
-    });
-  }
-);
+Cypress.Commands.add("dataId", (value, timeout) => {
+  return cy.get(`[data-testid=${value}]`, {
+    timeout: timeout ? timeout : 10000,
+  });
+});
+
+Cypress.Commands.add("dataBW", (value, timeout) => {
+  return cy.get(`[data-baseweb=${value}]`, {
+    timeout: timeout ? timeout : 10000,
+  });
+});

--- a/cypress/support/listingPageUtils.ts
+++ b/cypress/support/listingPageUtils.ts
@@ -1,0 +1,27 @@
+import { clickLabelGroupTab } from "../e2e/Labels/utilsAndConstants/labelsUtils";
+import { clickCheck } from "./clickUtils";
+
+export const clickUpdateActionButton = (options: {
+  name?: string;
+  condition?: string;
+  groupName?: string;
+}) => {
+  const { name, condition, groupName } = options;
+  if (groupName) {
+    clickLabelGroupTab(groupName);
+  }
+
+  cy.get('div[data-testid="stHorizontalBlock"]')
+    .should("exist")
+    .contains(name ? name : condition)
+    .should("exist")
+    .parents('div[data-testid="stHorizontalBlock"]') // finds all the parents of the element with labelName
+    .should("exist")
+    .within(() => {
+      // Only searches within specific stHorizontalBlock that has probeName
+      clickCheck({
+        clickElem: 'div[data-testid="column"]',
+        contains: "✏️",
+      });
+    });
+};

--- a/cypress/support/testConstants.ts
+++ b/cypress/support/testConstants.ts
@@ -1,0 +1,28 @@
+export const BUTTON_TEXT = {
+  CREATE: "Create",
+  UPDATE: "Update",
+  CANCEL: "Cancel",
+  NEW: "New",
+  NEW_GROUPED: "New (in group)",
+  NEW_DYNAMIC_GROUPED: "New dynamic grouped labels",
+};
+
+export const MENU_TEXT = {
+  LABELS: "Labels",
+  HOME: "Home",
+  SETTINGS: "Settings",
+  WAREHOUSES: "Warehouses",
+  QUERIES: "Queries",
+  PROBES: "Probes",
+  LABS: "Labs",
+};
+
+export const HEADER_TEXT = {
+  LABELS: "Query Labels",
+  HOME: "Welcome To Sundeck OpsCenter",
+  CREATE_LABEL: "New Label",
+  UPDATE_LABEL: "Edit Label",
+  PROBES: "Query Probes",
+  CREATE_PROBE: "New Probe",
+  UPDATE_PROBE: "Edit Probe",
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "cypress": "^12.16.0",
+        "cypress": "^13.2.0",
         "typescript": "^5.2.2"
       },
       "name": "opscenter",
@@ -35,9 +35,9 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
       },
@@ -45,9 +45,9 @@
       "engines": {
         "node": ">= 6"
       },
-      "integrity": "sha512-M83/wfQ1EkspjkE2lNWNV5ui2Cv7UCv1swW1DqljahbzLVWltcsexQh8jYtuS/vzFXP+HySntGM83ZXA9fn17w==",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.11.tgz",
-      "version": "2.88.11"
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "version": "3.0.1"
     },
     "node_modules/@cypress/xvfb": {
       "dependencies": {
@@ -70,9 +70,9 @@
     },
     "node_modules/@types/node": {
       "dev": true,
-      "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A==",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz",
-      "version": "14.18.53"
+      "integrity": "sha512-/4QOuy3ZpV7Ya1GTRz5CYSz3DgkKpyUptXuQ5PPce7uuyJAOR7r9FhkmxJfvcNUXyklbC63a+YvB3jxy7s9ngw==",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.18.tgz",
+      "version": "18.17.18"
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "dev": true,
@@ -547,9 +547,9 @@
         "cypress": "bin/cypress"
       },
       "dependencies": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -582,9 +582,10 @@
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
@@ -592,12 +593,12 @@
       },
       "dev": true,
       "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       },
       "hasInstallScript": true,
-      "integrity": "sha512-mwv1YNe48hm0LVaPgofEhGCtLwNIQEjmj2dJXnAkY1b4n/NE9OtgPph4TyS+tOtYp5CKtRmDvBzWseUXQTjbTg==",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.16.0.tgz",
-      "version": "12.16.0"
+      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+      "version": "13.2.0"
     },
     "node_modules/dashdash": {
       "dependencies": {
@@ -1488,6 +1489,15 @@
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
       "version": "5.6.0"
     },
+    "node_modules/process": {
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "version": "0.11.10"
+    },
     "node_modules/proxy-from-env": {
       "dev": true,
       "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
@@ -1534,6 +1544,12 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
       "version": "6.10.4"
     },
+    "node_modules/querystringify": {
+      "dev": true,
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "version": "2.2.0"
+    },
     "node_modules/request-progress": {
       "dependencies": {
         "throttleit": "^1.0.0"
@@ -1542,6 +1558,12 @@
       "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
       "version": "3.0.0"
+    },
+    "node_modules/requires-port": {
+      "dev": true,
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "version": "1.0.0"
     },
     "node_modules/restore-cursor": {
       "dependencies": {
@@ -1783,16 +1805,27 @@
     },
     "node_modules/tough-cookie": {
       "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "dev": true,
       "engines": {
-        "node": ">=0.8"
+        "node": ">=6"
       },
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "version": "2.5.0"
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "version": "4.1.3"
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      },
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "version": "0.2.0"
     },
     "node_modules/tslib": {
       "dev": true,
@@ -1860,6 +1893,16 @@
       "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
       "version": "4.0.0"
+    },
+    "node_modules/url-parse": {
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      },
+      "dev": true,
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "version": "1.5.10"
     },
     "node_modules/uuid": {
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "cypress": "^12.16.0",
+    "cypress": "^13.2.0",
     "typescript": "^5.2.2"
   },
   "name": "opscenter",


### PR DESCRIPTION
- dechunks the probes tests into smaller segments
- takes some of the labels utils/constants and moves them to the support file since they work in other scopes (when having to do with the listing pages, headers, and buttons)
- Adds ability to verify field values on the probes form (labels form already addressed by #328)
- Adds update tests to probes

closes #80 