### PR TITLE
Save artifacts from all e2e test runs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -150,7 +150,6 @@ jobs:
           headless: true
           record: false
       - uses: actions/upload-artifact@v3
-        if: failure()
         with:
           name: cypress-artifacts
           path: |


### PR DESCRIPTION
- this is to make sure we can get the artifacts (for the time being) to see how tests that fail, but have successful retries, could be improved.