### PR TITLE
Don't skip the snowflake-based unit tests if cypress fails

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -71,7 +71,7 @@ jobs:
         run: poetry run python deploy/devdeploy.py --profile opscenter
   unit-tests:
     runs-on: ubuntu-latest
-    continue-on-error: true
+    if: ${{ always() }}
     needs: [devdeploy-with-materialization, cypress-tests]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I've been seeing the `tests/unit` tests not getting when cypress fails run since #327 because the "unit-tests" job will be skipped since it's marked as depending on "cypress-tests" (to make the jobs serial instead of parallel).

My change here isn't entirely correct as we would want to skip `unit-tests` if the devdeploy job fails, but it would still be executed after this change. I'm not sure if there is an easy way to express that without re-working the jobs (which I don't want to do right now).