### PR TITLE
_Always_ upload cypress. Messed up original change.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -150,6 +150,7 @@ jobs:
           headless: true
           record: false
       - uses: actions/upload-artifact@v3
+        if: ${{ always() }}
         with:
           name: cypress-artifacts
           path: |


### PR DESCRIPTION
When we removed the `if failure()`, we inadvertently broke uploading the videos when cypress is not successful (as Github would bail out of the workflow due to the failing step). Need to explicitly tell github to always run the upload-artifact step.