### PR TITLE
Rewrite the python warehouse schedule task body in SQL

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -9,7 +9,7 @@ from .common import (  # noqa F401
 )
 from .labels import PredefinedLabel
 from .session import snowpark_session
-from .wh_sched import WarehouseSchedulesTask  # noqa F401
+from .wh_sched import WarehouseSchedulesTask, regenerate_alter_statements  # noqa F401
 
 
 def validate_predefined_labels(sess: snowflake.snowpark.Session):

--- a/app/crud/base.py
+++ b/app/crud/base.py
@@ -87,6 +87,20 @@ class BaseOpsCenterModel(BaseModel):
         return obj
 
     @classmethod
+    def batch_write(cls, session, data: List["BaseOpsCenterModel"], overwrite=False):
+        """
+        Writes a list of objects to the table. If overwrite is True, the table is truncated before writing.
+        :param session:
+        :param data:
+        :param overwrite:
+        :return:
+        """
+        df = session.create_dataframe([d.to_row() for d in data])
+        df.write.mode("overwrite" if overwrite else "append").save_as_table(
+            f"INTERNAL.{cls.table_name}"
+        )
+
+    @classmethod
     def batch_read(cls, session, sortby=None) -> List["BaseOpsCenterModel"]:
         """
         Reads all rows from the table and returns them as a list of objects.

--- a/app/crud/common.py
+++ b/app/crud/common.py
@@ -3,10 +3,15 @@ from .labels import Label
 from .probes import Probe
 from .errors import summarize_error
 from .session import snowpark_session
-from .wh_sched import WarehouseSchedules
+from .wh_sched import WarehouseSchedules, WarehouseAlterStatements
 
 # A "registry" of CRUD types and the implementation class
-_TYPES = {"LABEL": Label, "PROBE": Probe, "WAREHOUSE_SCHEDULES": WarehouseSchedules}
+_TYPES = {
+    "LABEL": Label,
+    "PROBE": Probe,
+    "WAREHOUSE_SCHEDULES": WarehouseSchedules,
+    "WAREHOUSE_ALTER_STATEMENTS": WarehouseAlterStatements,
+}
 
 
 def create_table(session, entity_type):

--- a/app/crud/wh_sched.py
+++ b/app/crud/wh_sched.py
@@ -143,6 +143,41 @@ class WarehouseSchedules(BaseOpsCenterModel):
         ).collect()
 
 
+class WarehouseAlterStatements(BaseOpsCenterModel):
+    """
+    Stores the ALTER WAREHOUSE statements for a given schedule.
+    """
+
+    table_name: ClassVar[str] = "WAREHOUSE_ALTER_STATEMENTS"
+    id_val: str
+    alter_statement: str
+
+    def get_id_col(self) -> str:
+        return "id_val"
+
+    def get_id(self) -> str:
+        return self.id_val
+
+    @validator("id_val", allow_reuse=True)
+    def verify_id(cls, v):
+        if not v:
+            raise ValueError("ID is required")
+        assert isinstance(v, str)
+        return v
+
+    @validator("alter_statement", allow_reuse=True)
+    def verify_alter_statement(cls, v):
+        if not v:
+            raise ValueError("The alter statement SQL is required")
+        assert isinstance(v, str)
+        return v
+
+    @classmethod
+    def create_table(cls, session, with_catalog_views=False):
+        # Never create a catalog view for this table
+        super(WarehouseAlterStatements, cls).create_table(session, False)
+
+
 def describe_warehouse(session: Session, warehouse: str):
     wh_df = session.sql(f"show warehouses like '{warehouse}'").collect()
     wh_dict = wh_df[0].as_dict()
@@ -154,6 +189,34 @@ def describe_warehouse(session: Session, warehouse: str):
         scale_min=wh_dict.get("min_cluster_count", 0),
         scale_max=wh_dict.get("max_cluster_count", 0),
         warehouse_mode=wh_dict.get("scaling_policy", "Standard"),
+    )
+
+
+def generate_alter_from_schedule(
+    schedule: WarehouseSchedules,
+) -> WarehouseAlterStatements:
+    changes = []
+    if schedule.scale_min == 0 or schedule.scale_max == 0:
+        is_standard = True
+    else:
+        is_standard = False
+
+    changes.append(f"WAREHOUSE_SIZE = {_WAREHOUSE_SIZE_OPTIONS[schedule.size]}")
+    if "Snowpark" in schedule.size:
+        changes.append("WAREHOUSE_TYPE = SNOWPARK-OPTIMIZED")
+    else:
+        changes.append("WAREHOUSE_TYPE = STANDARD")
+    changes.append(f"AUTO_SUSPEND = {schedule.suspend_minutes}")
+    changes.append(f"AUTO_RESUME = {schedule.resume}")
+    if not is_standard:
+        changes.append(f"MIN_CLUSTER_COUNT = {schedule.scale_min}")
+        changes.append(f"MAX_CLUSTER_COUNT = {schedule.scale_max}")
+        if not schedule.warehouse_mode == "Inherit":
+            changes.append(f"SCALING_POLICY = {schedule.warehouse_mode}")
+
+    return WarehouseAlterStatements(
+        id_val=schedule.id_val,
+        alter_statement=f"alter warehouse {schedule.name} set {', '.join(changes)}",
     )
 
 
@@ -202,6 +265,21 @@ def update_warehouse(warehouse_now, warehouse_next):
     return ""
 
 
+def regenerate_alter_statements(session: Session, schedules: List[WarehouseSchedules]):
+    """
+    Given a list of WarehouseSchedules, generate the ALTER WAREHOUSE statements and write them to the
+    WAREHOUSE_ALTER_STATEMENTS table. Any rows in the WarehouseAlterStatements table which are not included in
+    the `schedules` will be deleted (e.g. `dataframe.write.mode('overwrite')`)
+    :param session: Snowpark session
+    :param schedules: List of WarehouseSessions
+    """
+    # Take the Schedule and generate the WarehouseAlterStatements object which contains the ALTER WAREHOUSE stmt.
+    alter_stmts = [generate_alter_from_schedule(schedule) for schedule in schedules]
+
+    # Write all the statements to the table, overwriting any existing statements.
+    WarehouseAlterStatements.batch_write(session, alter_stmts, overwrite=True)
+
+
 def update_task_state(session: Session, schedules: List[WarehouseSchedules]) -> bool:
     # Make sure we have at least one enabled schedule.
     enabled_schedules = [sch for sch in schedules if sch.enabled]
@@ -212,9 +290,10 @@ def update_task_state(session: Session, schedules: List[WarehouseSchedules]) -> 
     # Build the cron list for the enabled schedules
     alter_statements = []
     for offset in WarehouseSchedulesTask.task_offsets:
-        # For each "offset", generate two statements
-        #   1. ALTER TASK ... SET SCHEDULE = 'USING CRON ...'
-        #   2. ALTER TASK ... RESUME
+        # For each "offset", generate multiple statements
+        #   1. ALTER TASK ... SUSPEND
+        #   2. ALTER TASK ... SET SCHEDULE = 'USING CRON ...'
+        #   3. ALTER TASK ... RESUME
         alter_statements.extend(_make_alter_task_statements(schedules, offset))
 
     # Collect the statements together

--- a/app/ui/warehouse_utils.py
+++ b/app/ui/warehouse_utils.py
@@ -78,8 +78,6 @@ def verify_and_clean(
 
 def set_enabled(wh_name: str, enabled: bool):
     with connection.Connection.get() as conn:
-        # TODO I saw a case where one warehouse was in an indeterminate state for enabled (some false, some true).
-        # Keep an eye on this. May have to push the explicitly bool value.
         _ = conn.sql(
             f"update internal.{WarehouseSchedules.table_name} set enabled = ? where name = ?",
             params=[enabled, wh_name],

--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -17,7 +17,7 @@ from warehouse_utils import (
     verify_and_clean,
     populate_initial,
     set_enabled,
-    update_task_state,
+    after_schedule_change,
 )
 from crud.errors import summarize_error
 
@@ -62,7 +62,7 @@ class Warehouses(Container):
         # Twiddle the task state
         if new_row:
             with connection.Connection.get() as conn:
-                update_task_state(conn)
+                after_schedule_change(conn)
 
         return new_row, data, current, comment
 
@@ -203,7 +203,7 @@ class Warehouses(Container):
             new_row.id_val = uuid.uuid4().hex
             new_row.write(conn)
             # Twiddle the task state after adding a new schedule
-            update_task_state(conn)
+            after_schedule_change(conn)
 
     def on_delete_click_internal(self, *args) -> Optional[str]:
         row = args[0][0]
@@ -218,7 +218,7 @@ class Warehouses(Container):
             [i.update(conn, i) for i in new_warehouses]
 
             # Twiddle the task state after adding a new schedule
-            update_task_state(conn)
+            after_schedule_change(conn)
 
     def on_update_click_internal(self, *args) -> Optional[str]:
         if args[3] is not None:
@@ -233,7 +233,7 @@ class Warehouses(Container):
         with connection.Connection.get() as conn:
             [i.update(conn, i) for i in new_warehouses]
             # Twiddle the task state after a schedule has changed
-            update_task_state(conn)
+            after_schedule_change(conn)
 
     def list(self):
         if os.environ.get("OPSCENTER_LOCAL_DEV", False):

--- a/bootstrap/011_warehouse_schedules.sql
+++ b/bootstrap/011_warehouse_schedules.sql
@@ -1,18 +1,105 @@
 
 -- NB. Table is created in 090_post_setup.sql because you cannot call python procs from the setup.sql
 
-CREATE OR REPLACE PROCEDURE ADMIN.UPDATE_WH_SCHEDULES()
-    RETURNS text
-    language python
-    runtime_version = "3.10"
-    handler = 'run'
-    packages = ('snowflake-snowpark-python', 'pydantic')
-    imports = ('{{stage}}/python/crud.zip')
-    EXECUTE AS OWNER
+-- CREATE TABLE IF NOT EXISTS internal.task_warehouse_schedule(RUN TIMESTAMP_LTZ(9), SUCCESS BOOLEAN, OUTPUT VARIANT)
+
+CREATE OR REPLACE PROCEDURE INTERNAL.UPDATE_WAREHOUSE_SCHEDULES()
+    RETURNS VARIANT
+    language sql
  AS
-$$
-from crud import WarehouseSchedulesTask
-def run(session):
-    task = WarehouseSchedulesTask(session)
-    return task.run()
-$$;
+DECLARE
+    task_outcome variant;
+    this_run timestamp_ltz default (select current_timestamp());
+    last_run timestamp_ltz default (select run from internal.task_warehouse_schedule order by run desc limit 1);
+BEGIN
+    call internal.UPDATE_WAREHOUSE_SCHEDULES(:last_run, :this_run) into :task_outcome;
+    return task_outcome;
+END;
+
+CREATE OR REPLACE PROCEDURE INTERNAL.UPDATE_WAREHOUSE_SCHEDULES(last_run timestamp_ltz, this_run timestamp_ltz)
+    RETURNS VARIANT
+    language sql
+ AS
+DECLARE
+    task_outcome variant default (select object_construct());
+BEGIN
+    if (this_run is NULL) then
+        this_run := (select current_timestamp());
+    end if;
+
+    if (last_run is NULL) then
+        last_run := (select run from internal.task_warehouse_schedule order by run desc limit 1);
+        -- If we don't have any rows in internal.task_warehouse_schedule, rewind far enough that we will just pick
+        -- the current WH schedule and not think it has already been run.
+        if (last_run is NULL) then
+            last_run := (select timestampadd('days', -1, current_timestamp));
+        end if;
+    end if;
+
+    -- TODO the WEEK_START session parameter can alter what DAYOFWEEK returns.
+    let is_weekday boolean := (select DAYOFWEEK(:this_run) not in (0, 6));
+
+    -- Get the warehouse schedule to apply.
+    -- Get the latest (greatest start_at), enabled schedules which match the day of the week that should be applied
+    -- since the last time the task ran.
+    let res resultset := (
+        with schedules as(
+          select *, TIMESTAMP_FROM_PARTS(date_trunc('day', :this_run)::DATE, start_at) as ts
+          from internal.wh_schedules
+          where
+              enabled = TRUE and
+              weekday = :is_weekday and
+              ts > :last_run and ts <= :this_run
+        ), ids as(
+            select distinct(last_value(id_val)) over (partition by name order by ts) from schedules
+        ) select sch.name, sch.id_val, alt.alter_statement
+            from internal.wh_schedules sch
+                left outer join internal.warehouse_alter_statements alt on sch.id_val = alt.id_val
+            where sch.id_val in (select * from ids)
+    );
+
+    -- build some metadata
+    let ids array := (select array_agg("ID_VAL") from table(result_scan(last_query_id())));
+    task_outcome := (select object_insert(:task_outcome, 'num_candidates', array_size(:ids)));
+    task_outcome := (select object_insert(:task_outcome, 'candidates', :ids));
+    task_outcome := (select object_insert(:task_outcome, 'last_run', :last_run));
+    task_outcome := (select object_insert(:task_outcome, 'this_run', :this_run));
+
+    let c1 cursor for res;
+
+    let success boolean := TRUE;
+    let warehouses_updated := 0;
+    let statements array := array_construct();
+    for schedule in c1 do
+        let sch_outcome string := '';
+        begin
+            -- Make sure the about left outer join matched a row.
+            if (length(coalesce(schedule.alter_statement, '')) = 0) then
+                sch_outcome := 'No alter statement found for warehouse ' || schedule.name;
+                success := FALSE;
+            else
+                sch_outcome := 'Successfully applied warehouse schedule for ' || schedule.name;
+                execute immediate schedule.alter_statement;
+                warehouses_updated := warehouses_updated + 1;
+            end if;
+        exception
+            when other then
+                sch_outcome := 'Exception occurred when applying warehouse schedules for ' || schedule.name || ', error: ' || :sqlerrm;
+                SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', :sch_outcome,
+                    'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
+                success := FALSE;
+        end;
+        statements := (select array_append(:statements, :sch_outcome));
+    end for;
+    task_outcome := (select object_insert(:task_outcome, 'warehouses_updated', :warehouses_updated));
+    task_outcome := (select object_insert(:task_outcome, 'statements', :statements));
+
+    INSERT INTO internal.task_warehouse_schedule SELECT :this_run, :success, :task_outcome;
+    return task_outcome;
+EXCEPTION
+    WHEN OTHER THEN
+        SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Exception occurred when applying warehouse schedules.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
+        task_outcome := (select object_insert(object_insert(:task_outcome, 'SQLERRM', :sqlerrm), 'SQLSTATE', :sqlstate));
+        INSERT INTO internal.task_warehouse_schedule SELECT :this_run, FALSE, :task_outcome;
+        RAISE;
+END;

--- a/bootstrap/011_warehouse_schedules.sql
+++ b/bootstrap/011_warehouse_schedules.sql
@@ -78,7 +78,8 @@ BEGIN
                 sch_outcome := 'No alter statement found for warehouse ' || schedule.name;
                 success := FALSE;
             else
-                sch_outcome := 'Successfully applied warehouse schedule for ' || schedule.name;
+                -- Return the actual alter statement to know what was executed.
+                sch_outcome := schedule.alter_statement;
                 execute immediate schedule.alter_statement;
                 warehouses_updated := warehouses_updated + 1;
             end if;

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -69,8 +69,9 @@ CREATE OR REPLACE TASK TASKS.SFUSER_MAINTENANCE
 -- create the query_hash functions in TOOLS
 call INTERNAL.ENABLE_QUERY_HASH();
 
--- Create the WAREHOUSE_SCHEDULES table
+-- Create the tables defined in python
 call internal_python.create_table('WAREHOUSE_SCHEDULES');
+call internal_python.create_table('WAREHOUSE_ALTER_STATEMENTS');
 
 -- Populate the list of predefined labels
 call INTERNAL.POPULATE_PREDEFINED_LABELS();
@@ -336,7 +337,8 @@ CREATE OR REPLACE TASK TASKS.WAREHOUSE_SCHEDULING
     ALLOW_OVERLAPPING_EXECUTION = FALSE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "X-Small"
     as
-    select 1;
+    call INTERNAL.UPDATE_WAREHOUSE_SCHEDULES(NULL, NULL);
+
 
 -- This clarifies that the post setup script has been executed to match the current installed version.
 let version string := (select internal.get_version());

--- a/test/unit/test_warehouse_schedules.py
+++ b/test/unit/test_warehouse_schedules.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import uuid
+from common_utils import generate_unique_name
+
+
+def test_basic_warehouse_schedule(conn, timestamp_string):
+    wh_name = generate_unique_name("wh", timestamp_string).replace("-", "_")
+    try:
+        with conn() as cnx, cnx.cursor() as cur:
+            # Ease local dev if we have run materialization
+            _ = cur.execute(
+                "call internal_python.create_table('WAREHOUSE_SCHEDULES')"
+            ).fetchone()
+            _ = cur.execute(
+                "call internal_python.create_table('WAREHOUSE_ALTER_STATEMENTS')"
+            ).fetchone()
+            cur.execute("truncate table internal.WH_SCHEDULES").fetchone()
+
+            _ = cur.execute(
+                f"CREATE OR REPLACE WAREHOUSE {wh_name} WITH WAREHOUSE_SIZE = XSMALL"
+            ).fetchone()
+
+            id1 = uuid.uuid4().hex
+            id2 = uuid.uuid4().hex
+
+            # TODO Write and use crud-backed admin procedures. These procedures would generate the alter statement for us.
+            sql = f"""INSERT INTO INTERNAL.WH_SCHEDULES select '{id1}', '{wh_name}', '00:00:00', '12:00:00',
+                'X-Small', 1, TRUE, 0, 0, 'Standard', NULL, TRUE, null, TRUE"""
+            _ = cur.execute(sql).fetchone()
+
+            sql = f"""INSERT INTO INTERNAL.WH_SCHEDULES select '{id2}', '{wh_name}', '12:00:00', '23:59:00',
+                'Small', 5, TRUE, 0, 0, 'Standard', NULL, TRUE, null, TRUE"""
+            _ = cur.execute(sql).fetchone()
+
+            sql = (
+                f"INSERT INTO INTERNAL.WAREHOUSE_ALTER_STATEMENTS SELECT '{id1}', 'alter warehouse {wh_name} "
+                + " set WAREHOUSE_SIZE = XSMALL, WAREHOUSE_TYPE = STANDARD, AUTO_SUSPEND = 1, AUTO_RESUME = True'"
+            )
+            _ = cur.execute(sql).fetchone()
+
+            sql = (
+                f"INSERT INTO INTERNAL.WAREHOUSE_ALTER_STATEMENTS SELECT '{id2}', 'alter warehouse {wh_name} "
+                + " set WAREHOUSE_SIZE = SMALL, WAREHOUSE_TYPE = STANDARD, AUTO_SUSPEND = 1, AUTO_RESUME = True'"
+            )
+            _ = cur.execute(sql).fetchone()
+
+            # Assume the default account timezeone is "America/Los_Angeles". Due to weirdness with TIMESTAMP_LTZ
+            # through a procedure, these are shifted backwards from UTC to Los_Angeles because the procedure shifts
+            # them forward again. Probably something we don't understand...
+
+            # Should do nothing be we have no new schedule
+            row = cur.execute(
+                """call INTERNAL.UPDATE_WAREHOUSE_SCHEDULES(
+                CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', to_timestamp_ltz('2023-09-29 10:00:00')),
+                CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', to_timestamp_ltz('2023-09-29 10:15:00')));"""
+            ).fetchone()
+
+            obj = json.loads(row[0])
+            assert "warehouses_updated" in obj
+            assert obj["warehouses_updated"] == 0
+            assert "num_candidates" in obj
+            assert obj["num_candidates"] == 0
+
+            row = cur.execute(
+                """call INTERNAL.UPDATE_WAREHOUSE_SCHEDULES(
+                CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', to_timestamp_ltz('2023-09-29 11:45:00')),
+                CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', to_timestamp_ltz('2023-09-29 12:00:00')));"""
+            ).fetchone()
+
+            obj = json.loads(row[0])
+            assert "warehouses_updated" in obj
+            assert obj["warehouses_updated"] == 1
+            assert "num_candidates" in obj
+            assert obj["num_candidates"] == 1
+            assert "statements" in obj
+            assert len(obj["statements"]) == 1
+            assert "WAREHOUSE_SIZE = SMALL" in obj["statements"][0]
+    finally:
+        with conn() as cnx, cnx.cursor() as cur:
+            _ = cur.execute(f"DROP WAREHOUSE IF EXISTS {wh_name}").fetchone()


### PR DESCRIPTION
Not nearly complete. Only does the selection of schedules to consider, none of the building up of `alter warehouse` commands.

On top of #381 