### PR TITLE
Persist current 'enabled' value when creating new schedules

### DIFF
--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -170,7 +170,7 @@ class Warehouses(Container):
                 comment=comment if comment != "" else None,
                 start_at=convert_time_str(start),
                 finish_at=convert_time_str(finish),
-                enabled=st.session_state["enabled"],
+                enabled=st.session_state["enabled"] or False,
             )
         )
         return new_update

--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -16,7 +16,7 @@ from warehouse_utils import (
     convert_time_str,
     verify_and_clean,
     populate_initial,
-    flip_enabled,
+    set_enabled,
     update_task_state,
 )
 from crud.errors import summarize_error
@@ -170,6 +170,7 @@ class Warehouses(Container):
                 comment=comment if comment != "" else None,
                 start_at=convert_time_str(start),
                 finish_at=convert_time_str(finish),
+                enabled=st.session_state["enabled"],
             )
         )
         return new_update
@@ -274,7 +275,7 @@ class Warehouses(Container):
             "Enable Schedule",
             value=is_enabled,
             key="enabled",
-            on_change=lambda: flip_enabled(whfilter),
+            on_change=lambda: set_enabled(whfilter, st.session_state["enabled"]),
         )
 
         st.title("Weekdays")

--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -275,7 +275,9 @@ class Warehouses(Container):
             "Enable Schedule",
             value=is_enabled,
             key="enabled",
-            on_change=lambda: set_enabled(whfilter, st.session_state["enabled"]),
+            on_change=lambda: set_enabled(
+                whfilter, st.session_state["enabled"] or False
+            ),
         )
 
         st.title("Weekdays")

--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -170,7 +170,11 @@ class Warehouses(Container):
                 comment=comment if comment != "" else None,
                 start_at=convert_time_str(start),
                 finish_at=convert_time_str(finish),
-                enabled=st.session_state["enabled"] or False,
+                enabled=(
+                    st.session_state["enabled"]
+                    if "enabled" in st.session_state
+                    else False
+                ),
             )
         )
         return new_update
@@ -276,7 +280,12 @@ class Warehouses(Container):
             value=is_enabled,
             key="enabled",
             on_change=lambda: set_enabled(
-                whfilter, st.session_state["enabled"] or False
+                whfilter,
+                (
+                    st.session_state["enabled"]
+                    if "enabled" in st.session_state
+                    else False
+                ),
             ),
         )
 


### PR DESCRIPTION
We were not including the `enabled` attribute from the UI when creating a new schedule.

Then, potentially had some schedules which were enabled and one that was disabled. Flipping the checkbox would then invert all of the schedules and leave you with one enabled and the rest disabled. Changed the logic to read the checkbox's state instead of just inverting the enabled value in sql.

Also fixes a simple bug when switching to a different warehouse (generated a stacktrace) which was because we tried to get a connection while already having a connection.