### PR TITLE
Ensure that the prettified autoscaling values don't get interpreted a…

### DIFF
--- a/app/ui/warehouse_utils.py
+++ b/app/ui/warehouse_utils.py
@@ -29,6 +29,7 @@ def create_callback(data, row, **additions):
 def populate_initial(warehouse):
     with connection.Connection.get() as conn:
         warehouses = WarehouseSchedules.batch_read(conn, "start_at")
+        # There is no WarehouseSchedule defined for this warehouse yet.
         if any(i for i in warehouses if i.name == warehouse) == 0:
             wh = describe_warehouse(conn, warehouse)
             wh.write(conn)

--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -134,17 +134,18 @@ class Warehouses(Container):
         autoscale_min = st.number_input(
             key="AUTOSCALE_MIN",
             label="Min Clusters",
-            value=max(update.scale_min, 1),
-            disabled=update.scale_min == 0,
-            min_value=1,
+            value=update.st_min_cluster_value(),
+            disabled=not update.autoscaling_enabled(),
+            min_value=update.st_min_cluster_minvalue(),
             max_value=update.scale_max,
         )
         autoscale_max = st.number_input(
             key="AUTOSCALE_MAX",
             label="Max Clusters",
-            value=max(update.scale_max, 1),
-            disabled=update.scale_max == 0,
+            value=update.st_max_cluster_value(),
+            disabled=not update.autoscaling_enabled(),
             min_value=autoscale_min,
+            max_value=update.st_max_cluster_maxvalue(),
         )
         comment = st.text_input(
             key="COMMENT",


### PR DESCRIPTION
…s autoscaling being active

The UI tries to avoid showing scale min/max equal to 0 when autoscaling is not enabled; however, this cause the value of 1 (not zero) to be persisted on update. This causes the scheduling task to think that it has to include these values on `alter warehouse` which fails (since the warehouse is not enabled for autoscaling).

Push all of this down onto the WarehouseSchedules instance and add some unit tests.

Closes #392