### PR TITLE
Treat warehouse schedules as in the opscenter-configured timezone.

### DIFF
--- a/app/ui/pages/06_WarehouseSchedule.py
+++ b/app/ui/pages/06_WarehouseSchedule.py
@@ -1,7 +1,14 @@
+import streamlit as st
 import sthelp
-import warehouse_schedule
+from modules import add_custom_modules
 
 
 sthelp.chrome("Warehouse Schedule")
+
+# Load custom OpsCenter python modules
+if not add_custom_modules():
+    st.warning("Unable to load OpsCenter modules.")
+
+import warehouse_schedule  # noqa E402
 
 warehouse_schedule.display()

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import List, Dict
 
 
 def generate_unique_name(prefix, timestamp_string) -> str:
@@ -51,3 +52,17 @@ def delete_list_of_probes(conn, sql):
         for name in cur.execute(sql).fetchall():
             delete_probe_statement = f"call ADMIN.DELETE_PROBE('{name[0]}');"
             assert run_proc(conn, delete_probe_statement) is None
+
+
+def fetch_all_warehouse_schedules(conn) -> List[Dict]:
+    with conn() as cnx, cnx.cursor() as cur:
+        return cur.execute(
+            "select * from internal.wh_schedules order by name, weekday, start_at"
+        ).fetchall()
+
+
+def reset_timezone(conn):
+    with conn.cursor() as cur:
+        _ = cur.execute(
+            "call internal.set_config('default_timezone', 'America/Los_Angeles')"
+        ).fetchone()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -75,8 +75,8 @@ def timestamp_string(conn):
     delete_list_of_probes(conn, sql)
 
     scheds = fetch_all_warehouse_schedules(conn)
-    scheds.insert(0, "Warehouse Schedules:")
-    print("\n".join(scheds))
+    str_scheds = [str(s) for s in scheds]
+    print("Warehouse Schedules:\n" + "\n".join(str_scheds))
 
 
 @pytest.fixture(autouse=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,12 @@ import sys
 import datetime
 import pytest
 from contextlib import contextmanager
-from common_utils import delete_list_of_labels, delete_list_of_probes
+from common_utils import (
+    delete_list_of_labels,
+    delete_list_of_probes,
+    fetch_all_warehouse_schedules,
+    reset_timezone,
+)
 
 sys.path.append("../deploy")
 import helpers  # noqa E402
@@ -68,3 +73,13 @@ def timestamp_string(conn):
 
     # call a function that deletes all the labels that were created in the session
     delete_list_of_probes(conn, sql)
+
+    scheds = fetch_all_warehouse_schedules(conn)
+    scheds.insert(0, "Warehouse Schedules:")
+    print("\n".join(scheds))
+
+
+@pytest.fixture(autouse=True)
+def reset_timezone_before_test(conn):
+    with conn() as cnx:
+        reset_timezone(cnx)

--- a/test/unit/test_warehouse_schedules.py
+++ b/test/unit/test_warehouse_schedules.py
@@ -2,36 +2,150 @@ from __future__ import annotations
 
 import json
 import uuid
+from typing import List
 from common_utils import generate_unique_name
+from snowflake.connector import SnowflakeConnection
+
+
+def _create_warehouse_for_test(
+    conn: SnowflakeConnection, name: str, initial_size: str = "XSMALL"
+):
+    """
+    Creates the warehouse we will try to test schedules against. We want to avoid using this warehouse for any tests,
+    so we cordon it off on its own connection (else the DML will cause the current connection to use that WH).
+    :param conn: A connection to Snowflake.
+    :param name: The name of the warehouse to create.
+    :param initial_size: The size of the warehouse to create.
+    """
+    # Create the warehouse on its own connection to avoid using that warehouse for the test
+    with conn.cursor() as cur:
+        _ = cur.execute(
+            f"CREATE OR REPLACE WAREHOUSE {name} WITH WAREHOUSE_SIZE = {initial_size}"
+        ).fetchone()
+
+
+def _assert_no_updates(row: List):
+    obj = json.loads(row[0])
+    assert "num_candidates" in obj
+    assert obj["num_candidates"] == 0, f"Expected no schedules to match: {obj}"
+    assert "warehouses_updated" in obj
+    assert (
+        obj["warehouses_updated"] == 0
+    ), f"Expected no warehouses to be updated: {obj}"
+
+
+def _ensure_tables_created(conn):
+    """
+    Create the tables that are normally created by admin.finalize_setup() and clear out any old state.
+    """
+    with conn.cursor() as cur:
+        # Ease local dev if we have run materialization
+        _ = cur.execute(
+            "call internal_python.create_table('WAREHOUSE_SCHEDULES')"
+        ).fetchone()
+        _ = cur.execute(
+            "call internal_python.create_table('WAREHOUSE_ALTER_STATEMENTS')"
+        ).fetchone()
+        _ = cur.execute("truncate table internal.WH_SCHEDULES").fetchone()
+
+
+def _update_warehouse_schedules_sql(last_run: str, now: str) -> str:
+    # Assume the default account timezeone is "America/Los_Angeles". Due to weirdness with TIMESTAMP_LTZ
+    # through a procedure, these are shifted backwards from UTC to Los_Angeles because the procedure shifts
+    # them forward again. Probably something we don't understand...
+
+    return f"""call INTERNAL.UPDATE_WAREHOUSE_SCHEDULES(
+        CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', to_timestamp_ltz('{last_run}')),
+        CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', to_timestamp_ltz('{now}')));"""
 
 
 def test_basic_warehouse_schedule(conn, timestamp_string):
     wh_name = generate_unique_name("wh", timestamp_string).replace("-", "_")
     try:
-        with conn() as cnx, cnx.cursor() as cur:
-            # Ease local dev if we have run materialization
-            _ = cur.execute(
-                "call internal_python.create_table('WAREHOUSE_SCHEDULES')"
-            ).fetchone()
-            _ = cur.execute(
-                "call internal_python.create_table('WAREHOUSE_ALTER_STATEMENTS')"
-            ).fetchone()
-            cur.execute("truncate table internal.WH_SCHEDULES").fetchone()
+        with conn() as cnx:
+            _create_warehouse_for_test(cnx, wh_name)
 
-            _ = cur.execute(
-                f"CREATE OR REPLACE WAREHOUSE {wh_name} WITH WAREHOUSE_SIZE = XSMALL"
-            ).fetchone()
+        with conn() as cnx, cnx.cursor() as cur:
+            # Set up internal state normally handled in admin.finalize_setup()
+            _ensure_tables_created(cnx)
 
             id1 = uuid.uuid4().hex
             id2 = uuid.uuid4().hex
 
             # TODO Write and use crud-backed admin procedures. These procedures would generate the alter statement for us.
             sql = f"""INSERT INTO INTERNAL.WH_SCHEDULES select '{id1}', '{wh_name}', '00:00:00', '12:00:00',
-                'X-Small', 1, TRUE, 0, 0, 'Standard', NULL, TRUE, null, TRUE"""
+                'X-Small', 1, TRUE, 0, 0, 'Standard', NULL, TRUE, NULL, TRUE"""
             _ = cur.execute(sql).fetchone()
 
             sql = f"""INSERT INTO INTERNAL.WH_SCHEDULES select '{id2}', '{wh_name}', '12:00:00', '23:59:00',
-                'Small', 5, TRUE, 0, 0, 'Standard', NULL, TRUE, null, TRUE"""
+                'Small', 5, TRUE, 0, 0, 'Standard', NULL, TRUE, NULL, TRUE"""
+            _ = cur.execute(sql).fetchone()
+
+            sql = (
+                f"INSERT INTO INTERNAL.WAREHOUSE_ALTER_STATEMENTS SELECT '{id1}', 'alter warehouse {wh_name} "
+                + " set WAREHOUSE_SIZE = XSMALL, WAREHOUSE_TYPE = STANDARD, AUTO_SUSPEND = 1, AUTO_RESUME = True'"
+            )
+            _ = cur.execute(sql).fetchone()
+
+            sql = (
+                f"INSERT INTO INTERNAL.WAREHOUSE_ALTER_STATEMENTS SELECT '{id2}', 'alter warehouse {wh_name} "
+                + " set WAREHOUSE_SIZE = SMALL, WAREHOUSE_TYPE = STANDARD, AUTO_SUSPEND = 1, AUTO_RESUME = True'"
+            )
+            _ = cur.execute(sql).fetchone()
+
+            # Should do nothing be we have no new schedule
+            row = cur.execute(
+                _update_warehouse_schedules_sql(
+                    "2023-09-29 10:00:00", "2023-09-29 10:15:00"
+                )
+            ).fetchone()
+            _assert_no_updates(row)
+
+            row = cur.execute(
+                _update_warehouse_schedules_sql(
+                    "2023-09-29 11:45:00", "2023-09-29 12:00:00"
+                )
+            ).fetchone()
+
+            obj = json.loads(row[0])
+            assert "warehouses_updated" in obj
+            assert obj["warehouses_updated"] == 1
+            assert "num_candidates" in obj
+            assert obj["num_candidates"] == 1
+            assert "statements" in obj
+            assert len(obj["statements"]) == 1
+            assert "WAREHOUSE_SIZE = SMALL" in obj["statements"][0]
+    finally:
+        with conn() as cnx, cnx.cursor() as cur:
+            _ = cur.execute(f"DROP WAREHOUSE IF EXISTS {wh_name}").fetchone()
+
+
+def test_alternate_timezone(conn, timestamp_string):
+    wh_name = generate_unique_name("wh", timestamp_string).replace("-", "_")
+    try:
+        with conn() as cnx:
+            _create_warehouse_for_test(cnx, wh_name)
+
+        with conn() as cnx, cnx.cursor() as cur:
+            # The Snowflake Account's timezone is America/Los_Angeles (-0700), but we are configured OpsCenter to
+            # apply schedules as if they were in America/New_York (-0400).
+            _ = cur.execute(
+                "call internal.set_config('default_timezone', 'America/New_York')"
+            ).fetchone()
+
+            # Set up internal state normally handled in admin.finalize_setup()
+            _ensure_tables_created(cnx)
+
+            id1 = uuid.uuid4().hex
+            id2 = uuid.uuid4().hex
+
+            # TODO Write and use crud-backed admin procedures. These procedures would generate the alter statement for us.
+            sql = f"""INSERT INTO INTERNAL.WH_SCHEDULES select '{id1}', '{wh_name}', '00:00:00', '12:00:00',
+                'X-Small', 1, TRUE, 0, 0, 'Standard', NULL, TRUE, NULL, TRUE"""
+            _ = cur.execute(sql).fetchone()
+
+            sql = f"""INSERT INTO INTERNAL.WH_SCHEDULES select '{id2}', '{wh_name}', '12:00:00', '23:59:00',
+                'Small', 5, TRUE, 0, 0, 'Standard', NULL, TRUE, NULL, TRUE"""
             _ = cur.execute(sql).fetchone()
 
             sql = (
@@ -50,23 +164,18 @@ def test_basic_warehouse_schedule(conn, timestamp_string):
             # through a procedure, these are shifted backwards from UTC to Los_Angeles because the procedure shifts
             # them forward again. Probably something we don't understand...
 
-            # Should do nothing be we have no new schedule
+            # These times are in UTC-7 (based on when the task runs), but need to be applied to the schedules in UTC-4
             row = cur.execute(
-                """call INTERNAL.UPDATE_WAREHOUSE_SCHEDULES(
-                CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', to_timestamp_ltz('2023-09-29 10:00:00')),
-                CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', to_timestamp_ltz('2023-09-29 10:15:00')));"""
+                _update_warehouse_schedules_sql(
+                    "2023-09-29 07:45:00", "2023-09-29 08:00:00"
+                )
             ).fetchone()
-
-            obj = json.loads(row[0])
-            assert "warehouses_updated" in obj
-            assert obj["warehouses_updated"] == 0
-            assert "num_candidates" in obj
-            assert obj["num_candidates"] == 0
+            _assert_no_updates(row)
 
             row = cur.execute(
-                """call INTERNAL.UPDATE_WAREHOUSE_SCHEDULES(
-                CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', to_timestamp_ltz('2023-09-29 11:45:00')),
-                CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', to_timestamp_ltz('2023-09-29 12:00:00')));"""
+                _update_warehouse_schedules_sql(
+                    "2023-09-29 08:45:00", "2023-09-29 09:00:00"
+                )
             ).fetchone()
 
             obj = json.loads(row[0])
@@ -77,6 +186,168 @@ def test_basic_warehouse_schedule(conn, timestamp_string):
             assert "statements" in obj
             assert len(obj["statements"]) == 1
             assert "WAREHOUSE_SIZE = SMALL" in obj["statements"][0]
+
+            # This is actually last_run=14:25 and now=15:00 in UTC-4, so they should do nothing.
+            row = cur.execute(
+                _update_warehouse_schedules_sql(
+                    "2023-09-29 11:45:00", "2023-09-29 12:00:00"
+                )
+            ).fetchone()
+            _assert_no_updates(row)
+    finally:
+        with conn() as cnx, cnx.cursor() as cur:
+            _ = cur.execute(f"DROP WAREHOUSE IF EXISTS {wh_name}").fetchone()
+
+
+def test_from_london(conn, timestamp_string):
+    wh_name = generate_unique_name("wh", timestamp_string).replace("-", "_")
+    try:
+        with conn() as cnx:
+            _create_warehouse_for_test(cnx, wh_name)
+
+        with conn() as cnx, cnx.cursor() as cur:
+            # The Snowflake Account's timezone is America/Los_Angeles (-0700), but we are configured OpsCenter to
+            # apply schedules as if they were in Europe/London (+0100).
+            _ = cur.execute(
+                "call internal.set_config('default_timezone', 'Europe/London')"
+            ).fetchone()
+
+            # Set up internal state normally handled in admin.finalize_setup()
+            _ensure_tables_created(cnx)
+
+            (id1, id2, id3, id4, id5) = [uuid.uuid4().hex for x in range(1, 6)]
+
+            # TODO Write and use crud-backed admin procedures. These procedures would generate the alter statement for us.
+            sql = f"""INSERT INTO INTERNAL.WH_SCHEDULES select '{id1}', '{wh_name}', '00:00:00', '09:00:00',
+                'X-Small', 1, TRUE, 0, 0, 'Standard', NULL, TRUE, NULL, TRUE"""
+            _ = cur.execute(sql).fetchone()
+
+            sql = f"""INSERT INTO INTERNAL.WH_SCHEDULES select '{id2}', '{wh_name}', '09:00:00', '17:00:00',
+                'Medium', 15, TRUE, 0, 0, 'Standard', NULL, TRUE, NULL, TRUE"""
+            _ = cur.execute(sql).fetchone()
+
+            sql = f"""INSERT INTO INTERNAL.WH_SCHEDULES select '{id3}', '{wh_name}', '17:00:00', '23:59:00',
+                'Small', 5, TRUE, 0, 0, 'Standard', NULL, TRUE, NULL, TRUE"""
+            _ = cur.execute(sql).fetchone()
+
+            sql = (
+                f"INSERT INTO INTERNAL.WAREHOUSE_ALTER_STATEMENTS SELECT '{id1}', 'alter warehouse {wh_name} "
+                + " set WAREHOUSE_SIZE = XSMALL, WAREHOUSE_TYPE = STANDARD, AUTO_SUSPEND = 1, AUTO_RESUME = True'"
+            )
+            _ = cur.execute(sql).fetchone()
+
+            sql = (
+                f"INSERT INTO INTERNAL.WAREHOUSE_ALTER_STATEMENTS SELECT '{id2}', 'alter warehouse {wh_name} "
+                + " set WAREHOUSE_SIZE = MEDIUM, WAREHOUSE_TYPE = STANDARD, AUTO_SUSPEND = 15, AUTO_RESUME = True'"
+            )
+            _ = cur.execute(sql).fetchone()
+
+            sql = (
+                f"INSERT INTO INTERNAL.WAREHOUSE_ALTER_STATEMENTS SELECT '{id3}', 'alter warehouse {wh_name} "
+                + " set WAREHOUSE_SIZE = SMALL, WAREHOUSE_TYPE = STANDARD, AUTO_SUSPEND = 5, AUTO_RESUME = True'"
+            )
+            _ = cur.execute(sql).fetchone()
+
+            # Weekend nights run ETL
+            sql = f"""INSERT INTO INTERNAL.WH_SCHEDULES select '{id4}', '{wh_name}', '00:00:00', '22:00:00',
+                'X-Small', 0, TRUE, 0, 0, 'Standard', NULL, FALSE, NULL, TRUE"""
+            _ = cur.execute(sql).fetchone()
+
+            sql = f"""INSERT INTO INTERNAL.WH_SCHEDULES select '{id5}', '{wh_name}', '22:00:00', '23:59:00',
+                '2X-Large', 15, TRUE, 0, 0, 'Standard', NULL, FALSE, NULL, TRUE"""
+            _ = cur.execute(sql).fetchone()
+
+            sql = (
+                f"INSERT INTO INTERNAL.WAREHOUSE_ALTER_STATEMENTS SELECT '{id4}', 'alter warehouse {wh_name} "
+                + " set WAREHOUSE_SIZE = XSMALL, WAREHOUSE_TYPE = STANDARD, AUTO_SUSPEND = 0, AUTO_RESUME = True'"
+            )
+            _ = cur.execute(sql).fetchone()
+
+            sql = (
+                f"INSERT INTO INTERNAL.WAREHOUSE_ALTER_STATEMENTS SELECT '{id5}', 'alter warehouse {wh_name} "
+                + " set WAREHOUSE_SIZE = XXLARGE, WAREHOUSE_TYPE = STANDARD, AUTO_SUSPEND = 15, AUTO_RESUME = True'"
+            )
+            _ = cur.execute(sql).fetchone()
+
+            # weekday, 16:00 in UTC+1
+            row = cur.execute(
+                _update_warehouse_schedules_sql(
+                    "2023-09-29 07:45:00", "2023-09-29 08:00:00"
+                )
+            ).fetchone()
+            _assert_no_updates(row)
+
+            # weekday, 09:00 in utc+1
+            row = cur.execute(
+                _update_warehouse_schedules_sql(
+                    "2023-09-29 00:45:00", "2023-09-29 01:00:00"
+                )
+            ).fetchone()
+
+            obj = json.loads(row[0])
+            assert "num_candidates" in obj
+            assert (
+                obj["num_candidates"] == 1
+            ), f"Expected to have one candidate schedule: {obj}"
+            assert "warehouses_updated" in obj
+            assert (
+                obj["warehouses_updated"] == 1
+            ), f"Expected one warehouse to be updated: {obj}"
+            assert "statements" in obj
+            assert (
+                len(obj["statements"]) == 1
+            ), f"Expected an alter warehouse statement: {obj}"
+            assert "WAREHOUSE_SIZE = MEDIUM" in obj["statements"][0]
+            assert "AUTO_SUSPEND = 15" in obj["statements"][0]
+
+            # weekday, 17:00 in utc+1
+            row = cur.execute(
+                _update_warehouse_schedules_sql(
+                    "2023-09-29 08:45:00", "2023-09-29 09:00:00"
+                )
+            ).fetchone()
+
+            obj = json.loads(row[0])
+            assert "warehouses_updated" in obj
+            assert obj["warehouses_updated"] == 1
+            assert "num_candidates" in obj
+            assert obj["num_candidates"] == 1
+            assert "statements" in obj
+            assert len(obj["statements"]) == 1
+            assert "WAREHOUSE_SIZE = SMALL" in obj["statements"][0]
+            assert "AUTO_SUSPEND = 5" in obj["statements"][0]
+
+            # weekend, 09:00 in utc+1
+            row = cur.execute(
+                _update_warehouse_schedules_sql(
+                    "2023-09-30 00:45:00", "2023-09-30 01:00:00"
+                )
+            ).fetchone()
+            _assert_no_updates(row)
+
+            # weekend, 17:00 in utc+1
+            row = cur.execute(
+                _update_warehouse_schedules_sql(
+                    "2023-09-30 08:45:00", "2023-09-30 09:00:00"
+                )
+            ).fetchone()
+            _assert_no_updates(row)
+
+            # weekend, 22:00 in utc+1
+            row = cur.execute(
+                _update_warehouse_schedules_sql(
+                    "2023-09-30 13:45:00", "2023-09-30 14:00:00"
+                )
+            ).fetchone()
+            obj = json.loads(row[0])
+            assert "num_candidates" in obj
+            assert obj["num_candidates"] == 1
+            assert "warehouses_updated" in obj
+            assert obj["warehouses_updated"] == 1
+            assert "statements" in obj
+            assert len(obj["statements"]) == 1
+            assert "WAREHOUSE_SIZE = XXLARGE" in obj["statements"][0]
+            assert "AUTO_SUSPEND = 15" in obj["statements"][0]
     finally:
         with conn() as cnx, cnx.cursor() as cur:
             _ = cur.execute(f"DROP WAREHOUSE IF EXISTS {wh_name}").fetchone()


### PR DESCRIPTION
1. All warehouse schedule tasks should be marked as running in the configured opscenter timezone.
2. When the task runs, convert the current time and the last task run time to the configured timezone. Then, apply those times against the task schedule and execute the logic per usual.

Adds some (contrived) SQL unit tests to validate the logic of this task before we have the admin procedures.

Closes #396