### PR TITLE
Build stored procedures to administer warehouse schedules

### DIFF
--- a/app/crud/base.py
+++ b/app/crud/base.py
@@ -101,7 +101,9 @@ class BaseOpsCenterModel(BaseModel):
         )
 
     @classmethod
-    def batch_read(cls, session, sortby=None) -> List["BaseOpsCenterModel"]:
+    def batch_read(
+        cls, session, sortby=None, filter: lambda df: bool = None
+    ) -> List["BaseOpsCenterModel"]:
         """
         Reads all rows from the table and returns them as a list of objects.
         :param session:
@@ -109,6 +111,8 @@ class BaseOpsCenterModel(BaseModel):
         """
         df = session.table(f"INTERNAL.{cls.table_name}").to_pandas()
         df.columns = [c.lower() for c in df.columns]
+        if filter:
+            df = df[filter(df)]
         if sortby:
             df.sort_values(by=[sortby], inplace=True)
         arr = [cls(**dict(row)) for row in df.to_dict("records")]

--- a/app/ui/warehouse_utils.py
+++ b/app/ui/warehouse_utils.py
@@ -1,13 +1,10 @@
 import connection
-from snowflake.snowpark import Session
 from crud.wh_sched import (
     WarehouseSchedules,
     describe_warehouse,
-    update_task_state as crud_update_task_state,
-    regenerate_alter_statements as crud_regenerate_alter_statements,
+    after_schedule_change,
 )
-from crud.errors import summarize_error
-from typing import Optional, List, Tuple
+from typing import List
 import datetime
 
 
@@ -44,37 +41,6 @@ def convert_time_str(time_str) -> datetime.time:
     return datetime.datetime.strptime(time_str, "%I:%M %p").time()
 
 
-def verify_and_clean(
-    data: List[WarehouseSchedules], ignore_errors=False
-) -> Tuple[Optional[str], List[WarehouseSchedules]]:
-    if data[0].start_at != datetime.time(0, 0):
-        if ignore_errors:
-            data[0].start_at = datetime.time(0, 0)
-            data[0]._dirty = True
-        else:
-            return "First row must start at midnight.", data
-    if data[-1].finish_at != datetime.time(23, 59):
-        if ignore_errors:
-            data[-1].finish_at = datetime.time(23, 59)
-            data[0]._dirty = True
-        else:
-            return "Last row must end at midnight.", data
-    next_start = data[0]
-    for row in data[1:]:
-        if row.start_at != next_start.finish_at:
-            next_start.finish_at = row.start_at
-            next_start._dirty = True
-        if row.warehouse_mode == "Inherit":
-            row.warehouse_mode = next_start.warehouse_mode
-            row._dirty = True
-        next_start = row
-    try:
-        [i.validate(i.dict()) for i in data]
-    except Exception as e:
-        return summarize_error("Verify failed", e), data
-    return None, [i for i in data if i._dirty]
-
-
 def set_enabled(wh_name: str, enabled: bool):
     with connection.Connection.get() as conn:
         _ = conn.sql(
@@ -100,19 +66,3 @@ def time_filter(
         ]
     else:
         return base_times
-
-
-def after_schedule_change(session: Session) -> bool:
-    """
-    Takes the current collection of warehouse schedules, records the alter warehouse statement
-    for each schedule, and appropriately schedules the tasks to run.
-    :return: True if any task is scheduled to run (resumed), False otherwise.
-    """
-    schedules = WarehouseSchedules.batch_read(session, sortby="start_at")
-
-    # Generate alter statements for each schedule
-    crud_regenerate_alter_statements(session, schedules)
-    # Update the task's state
-    task_started = crud_update_task_state(session, schedules)
-
-    return task_started

--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -5,6 +5,8 @@ import connection
 from crud.wh_sched import (
     WarehouseSchedules,
     _WAREHOUSE_SIZE_OPTIONS,
+    after_schedule_change,
+    verify_and_clean,
 )
 from table import build_table, Actions
 from typing import Optional, List
@@ -14,10 +16,8 @@ from warehouse_utils import (
     time_filter,
     create_callback,
     convert_time_str,
-    verify_and_clean,
     populate_initial,
     set_enabled,
-    after_schedule_change,
 )
 from crud.errors import summarize_error
 
@@ -58,11 +58,6 @@ class Warehouses(Container):
         except Exception as e:
             comment = summarize_error("Verify failed", e)
             new_row = None
-
-        # Twiddle the task state
-        if new_row:
-            with connection.Connection.get() as conn:
-                after_schedule_change(conn)
 
         return new_row, data, current, comment
 

--- a/bootstrap/011_warehouse_schedules.sql
+++ b/bootstrap/011_warehouse_schedules.sql
@@ -116,3 +116,175 @@ AS
 $$
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
 $$;
+
+
+CREATE OR REPLACE PROCEDURE ADMIN.CREATE_WAREHOUSE_SCHEDULE(warehouse_name text, size text, start_at time, finish_at time, is_weekday boolean, suspend_minutes number, autoscale_mode text, autoscale_min number, autoscale_max number, auto_resume boolean, comment text)
+    RETURNS TEXT
+    LANGUAGE PYTHON
+    runtime_version = "3.10"
+    handler = 'create_warehouse_schedule'
+    packages = ('snowflake-snowpark-python', 'pydantic')
+    imports = ('{{stage}}/python/crud.zip')
+    EXECUTE AS OWNER
+AS
+$$
+import datetime
+import uuid
+from crud.wh_sched import WarehouseSchedules, after_schedule_change, merge_new_schedule, verify_and_clean
+def create_warehouse_schedule(session, name: str, size: str, start: datetime.time, finish: datetime.time, weekday: bool, suspend_minutes: int, autoscale_mode: str, autoscale_min: int, autoscale_max: int, auto_resume: bool, comment: str):
+    current_scheds = WarehouseSchedules.find_all(session, name, weekday)
+
+    # Figure out if the schedules are enabled or disabled
+    is_enabled = all(s.enabled for s in current_scheds) if len(current_scheds) > 0 else False
+
+    new_sched = WarehouseSchedules.parse_obj(dict(
+        id_val=uuid.uuid4().hex,
+        name=name,
+        size=size,
+        start_at=start,
+        finish_at=finish,
+        suspend_minutes=suspend_minutes,
+        warehouse_mode=autoscale_mode,
+        scale_min=autoscale_min,
+        scale_max=autoscale_max,
+        resume=auto_resume,
+        weekday=weekday,
+        enabled=is_enabled,
+        comment=comment,
+    ))
+
+    # Handles pre-existing schedules or no schedules for this warehouse.
+    new_scheds = merge_new_schedule(new_sched, current_scheds)
+
+    err_msg, new_scheds = verify_and_clean(new_scheds)
+    if err_msg is not None:
+        raise Exception(f"Failed to create schedule for {name}, {err_msg}")
+
+    # Write the new schedule
+    new_sched.write(session)
+    # Update any schedules that were affected by adding the new schedule
+    [i.update(session, i) for i in new_scheds if i.id_val != new_sched.id_val]
+    # Twiddle the task state after adding a new schedule
+    after_schedule_change(session)
+$$;
+
+
+CREATE OR REPLACE PROCEDURE ADMIN.DELETE_WAREHOUSE_SCHEDULE(name text, start_at time, finish_at time, weekday boolean)
+    RETURNS TEXT
+    LANGUAGE PYTHON
+    runtime_version = "3.10"
+    handler = 'delete_warehouse_schedule'
+    packages = ('snowflake-snowpark-python', 'pydantic')
+    imports = ('{{stage}}/python/crud.zip')
+    EXECUTE AS OWNER
+AS
+$$
+import datetime
+from crud.wh_sched import WarehouseSchedules, verify_and_clean, after_schedule_change
+def delete_warehouse_schedule(session, name: str, start: datetime.time, finish: datetime.time, is_weekday: bool):
+    # Find a matching schedule
+    row = WarehouseSchedules.find_one(session, name, start, finish, is_weekday)
+    if not row:
+        raise Exception(f"Could not find warehouse schedule: {name}, {start}, {finish}, {'weekday' if is_weekday else 'weekend'}")
+
+    # Delete that schedule (leaving a hole)
+    to_delete = WarehouseSchedules.construct(id_val = row.id_val)
+    to_delete.delete(session)
+
+    # Read the remaining schedules
+    new_scheds = WarehouseSchedules.batch_read(session, filter=lambda df: ((df.name == name) & (df.weekday == is_weekday)))
+
+    # Collapse any gaps in the schedule left by the delete
+    err_msg, new_scheds = verify_and_clean(new_scheds, ignore_errors=True)
+    if err_msg is not None:
+        # Shouldn't happen since ignored_errors=True, but just in case
+        raise Exception(f"Failed to reorder schedule after delete for {name}, {err_msg}")
+
+    # Persist all the updates from filling the gap
+    [i.update(session, i) for i in new_scheds]
+
+    # Twiddle the task state after adding a new schedule
+    after_schedule_change(session)
+$$;
+
+
+CREATE OR REPLACE PROCEDURE ADMIN.UPDATE_WAREHOUSE_SCHEDULE(warehouse_name text, start_at time, finish_at time, weekday boolean, size text, suspend_minutes number, autoscale_mode text, autoscale_min number, autoscale_max number, auto_resume boolean, comment text)
+    RETURNS TEXT
+    LANGUAGE PYTHON
+    runtime_version = "3.10"
+    handler = 'update_warehouse_schedule'
+    packages = ('snowflake-snowpark-python', 'pydantic')
+    imports = ('{{stage}}/python/crud.zip')
+    EXECUTE AS OWNER
+AS
+$$
+import datetime
+from crud.wh_sched import WarehouseSchedules, after_schedule_change, update_existing_schedule
+def update_warehouse_schedule(session, name: str, start: datetime.time, finish: datetime.time, is_weekday: bool, size: str, suspend_minutes: int, autoscale_mode: str, autoscale_min: int, autoscale_max: int, auto_resume: bool, comment: str):
+    # Find a matching schedule
+    old_schedule = WarehouseSchedules.find_one(session, name, start, finish, is_weekday)
+    if not old_schedule:
+        raise Exception(f"Could not find warehouse schedule: {name}, {start}, {finish}, {'weekday' if is_weekday else 'weekend'}")
+
+    # Make the new version of that schedule with the same id_val
+    new_schedule = WarehouseSchedules.parse_obj(dict(
+        id_val=old_schedule.id_val,
+        name=name,
+        size=size,
+        start_at=start,
+        finish_at=finish,
+        suspend_minutes=suspend_minutes,
+        warehouse_mode=autoscale_mode,
+        scale_min=autoscale_min,
+        scale_max=autoscale_max,
+        resume=auto_resume,
+        comment=comment,
+        enabled=old_schedule.enabled,
+    ))
+
+    # Read the current schedules
+    schedules = WarehouseSchedules.find_all(session, name, new_schedule.weekday)
+
+    # Update the WarehouseSchedule instance for this warehouse
+    schedules_needing_update = update_existing_schedule(old_schedule.id_val, new_schedule, schedules)
+
+    # Persist all updates to the table
+    [i.update(session, i) for i in schedules_needing_update]
+
+    # Twiddle the task state after a schedule has changed
+    after_schedule_change(session)
+$$;
+
+
+CREATE OR REPLACE PROCEDURE ADMIN.ENABLE_WAREHOUSE_SCHEDULING(warehouse_name text)
+    RETURNS TEXT
+    LANGUAGE PYTHON
+    runtime_version = "3.10"
+    handler = 'run'
+    packages = ('snowflake-snowpark-python', 'pydantic')
+    imports = ('{{stage}}/python/crud.zip')
+    EXECUTE AS OWNER
+AS
+$$
+from crud.wh_sched import WarehouseSchedules
+def run(session, name: str):
+    # Find a matching schedule
+    WarehouseSchedules.enable_scheduling(session, name, True)
+$$;
+
+
+CREATE OR REPLACE PROCEDURE ADMIN.DISABLE_WAREHOUSE_SCHEDULING(warehouse_name text)
+    RETURNS TEXT
+    LANGUAGE PYTHON
+    runtime_version = "3.10"
+    handler = 'run'
+    packages = ('snowflake-snowpark-python', 'pydantic')
+    imports = ('{{stage}}/python/crud.zip')
+    EXECUTE AS OWNER
+AS
+$$
+from crud.wh_sched import WarehouseSchedules
+def run(session, name: str):
+    # Find a matching schedule
+    WarehouseSchedules.enable_scheduling(session, name, False)
+$$;


### PR DESCRIPTION
All procedures operate on the combination of warehouse name and weekday/weekend. Tries to mimic the UX of the UI by inserting the new schedule after one that already exists.

* Create schedule
* Update schedule (by start_finish time)
* Delete schedule (by start/finish time)
* Enable all schedules for warehouse + weekday/weekend
* Disable all scheduels for warehouse + weekday/weekend

No new snowflake-level tests (yet), but implicitly tested by the already-existing warehouse scheduling tests. I have plans to write additional tests in follow-on work.

Closes #335

Also adds some ORM-like API additions to WarehouseSchedules to keep business logic out of the procedures.