### PR TITLE
Collapse warehouse filter if warehouse is selected

### DIFF
--- a/app/ui/warehouse_schedule.py
+++ b/app/ui/warehouse_schedule.py
@@ -38,7 +38,9 @@ class WarehouseSummary(BaseOpsCenterModel):
 
 def display():
     st.title("Manage Warehouses")
-    filter_container = st.expander("Filters", expanded=True)
+    filter_container = st.expander(
+        "Filters", expanded="warehouse" not in st.session_state
+    )
     with filter_container:
         s1, s2 = st.columns(2)
 


### PR DESCRIPTION
An irritant -- if I've selected a warehouse, stop expanding the warehouse filter when on the warehouse schedules page.