### PR TITLE
Prevent multiple main checks from running concurrently

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,7 @@
 name: Main Build Check
 
+concurrency: main
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Have seen some test-deploy's fail but always pass on re-run. I think it's because the Main Build checks are running concurrently and the test-deploy is not using a unique name. Band-aid for the moment.