### PR TITLE
Preserve weekday through form

### DIFF
--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -166,6 +166,7 @@ class Warehouses(Container):
                 comment=comment if comment != "" else None,
                 start_at=convert_time_str(start),
                 finish_at=convert_time_str(finish),
+                weekday=update.weekday,
                 enabled=(
                     st.session_state["enabled"]
                     if "enabled" in st.session_state


### PR DESCRIPTION
`def form` forgot to pass the `weekday` attribute along which caused created/update to jump from the weekend section to the weekday section.

Closes #422

