### PR TITLE
Refresh the warehouse schedule row when it hasn't been changed

### DIFF
--- a/app/crud/test_wh_sched.py
+++ b/app/crud/test_wh_sched.py
@@ -293,8 +293,11 @@ def test_return_default_when_no_schedules(session):
         )
         mock_write.side_effect = lambda *args, **kwargs: writes.append(args[0])
 
-        schedules = wh_sched.fetch_schedules_with_defaults(session, "COMPUTE_WH")
+        schedules, default_only = wh_sched.fetch_schedules_with_defaults(
+            session, "COMPUTE_WH"
+        )
 
+        assert default_only
         assert len(schedules) == 2
 
         # The defaults from the _make_schedule(..) above
@@ -354,8 +357,11 @@ def test_update_default_warehouse_rows(session):
 
         mock_update.side_effect = update
 
-        schedules = wh_sched.fetch_schedules_with_defaults(session, "COMPUTE_WH")
+        schedules, default_only = wh_sched.fetch_schedules_with_defaults(
+            session, "COMPUTE_WH"
+        )
 
+        assert default_only
         assert len(schedules) == 2
 
         # The defaults from the _make_schedule(..) above

--- a/app/crud/test_wh_sched.py
+++ b/app/crud/test_wh_sched.py
@@ -294,11 +294,8 @@ def test_return_default_when_no_schedules(session):
         )
         mock_write.side_effect = lambda *args, **kwargs: writes.append(args[0])
 
-        schedules, default_only = wh_sched.fetch_schedules_with_defaults(
-            session, "COMPUTE_WH"
-        )
+        schedules = wh_sched.fetch_schedules_with_defaults(session, "COMPUTE_WH")
 
-        assert default_only
         assert len(schedules) == 2
 
         # The defaults from the _make_schedule(..) above
@@ -358,11 +355,8 @@ def test_update_default_warehouse_rows(session):
 
         mock_update.side_effect = update
 
-        schedules, default_only = wh_sched.fetch_schedules_with_defaults(
-            session, "COMPUTE_WH"
-        )
+        schedules = wh_sched.fetch_schedules_with_defaults(session, "COMPUTE_WH")
 
-        assert default_only
         assert len(schedules) == 2
 
         # The defaults from the _make_schedule(..) above

--- a/app/crud/wh_sched.py
+++ b/app/crud/wh_sched.py
@@ -190,7 +190,8 @@ class WarehouseSchedules(BaseOpsCenterModel):
     @classmethod
     def find_all(cls, session: Session, name: str) -> List["WarehouseSchedules"]:
         """
-        Syntactic sugar to return all schedules for a given warehouse and weekday/weekend.
+        Syntactic sugar to return all schedules for a given warehouse, including both weekday
+        and weekend schedules.
         """
         return cls.batch_read(
             session,
@@ -220,6 +221,11 @@ class WarehouseSchedules(BaseOpsCenterModel):
         finish_at: datetime.time,
         weekday: bool,
     ) -> Optional["WarehouseSchedules"]:
+        """
+        Returns the schedule from a warehouse matching the start_at, finish_at, and weekday
+        values. If no such schedule is found, this method returns `None`. If multiple schedules
+        are found, it raises a ValueError.
+        """
         rows = cls.batch_read(
             session,
             filter=lambda df: (

--- a/app/crud/wh_sched.py
+++ b/app/crud/wh_sched.py
@@ -188,7 +188,18 @@ class WarehouseSchedules(BaseOpsCenterModel):
         ).collect()
 
     @classmethod
-    def find_all(
+    def find_all(cls, session: Session, name: str) -> List["WarehouseSchedules"]:
+        """
+        Syntactic sugar to return all schedules for a given warehouse and weekday/weekend.
+        """
+        return cls.batch_read(
+            session,
+            sortby="start_at",
+            filter=lambda df: (df.name == name),
+        )
+
+    @classmethod
+    def find_all_with_weekday(
         cls, session: Session, name: str, weekday: bool
     ) -> List["WarehouseSchedules"]:
         """
@@ -275,6 +286,42 @@ class WarehouseAlterStatements(BaseOpsCenterModel):
 
 def convert_time_str(time_str) -> datetime.time:
     return datetime.datetime.strptime(time_str, "%I:%M %p").time()
+
+
+def fetch_schedules_with_defaults(
+    session: Session, warehouse: str
+) -> List[WarehouseSchedules]:
+    """
+    Returns the WarehouseSchedules for the given warehouse.
+    :param session: Snowpark session instance.
+    :param warehouse: The snowflake warehouse to filter on.
+    :return: A list of WarehouseSchedules for the given warehouse, creating and persisting
+    default schedules if none exist.
+    """
+    schedules = WarehouseSchedules.find_all(session, warehouse)
+    if len(schedules) == 0:
+        wh = describe_warehouse(session, warehouse)
+        wh.write(session)
+        schedules.append(wh)
+        wh2 = describe_warehouse(session, warehouse)
+        wh2.weekday = False
+        wh2.write(session)
+        schedules.append(wh2)
+    elif len(schedules) == 2 and all(not s.enabled for s in schedules):
+        # If we have only 2 schedules which are both disabled, refresh the warehouse. `show warehouses` doesn't
+        # use a warehouse, so we're probably OK doing this on every page-load.
+        wh = describe_warehouse(session, warehouse)
+        updated_schedules = []
+        for s in schedules:
+            # Copy the object so the two iterations of this loop don't use the same object (avoid 2 queries)
+            update = WarehouseSchedules(**wh.dict())
+            # Preserve the weekday flag and id_val
+            update.weekday = s.weekday
+            update.id_val = s.id_val
+            updated_schedules.append(s.update(session, update))
+        schedules = updated_schedules
+
+    return schedules
 
 
 def delete_warehouse_schedule(

--- a/app/ui/warehouse_utils.py
+++ b/app/ui/warehouse_utils.py
@@ -2,7 +2,6 @@ import connection
 from crud.base import transaction
 from crud.wh_sched import (
     WarehouseSchedules,
-    describe_warehouse,
     after_schedule_change,
 )
 from typing import List
@@ -23,19 +22,6 @@ def create_callback(data, row, **additions):
     for k, v in additions.items():
         setattr(row, k, v)
     return (row, data)
-
-
-def populate_initial(session, warehouse):
-    warehouses = WarehouseSchedules.batch_read(session, "start_at")
-    if any(i for i in warehouses if i.name == warehouse) == 0:
-        wh = describe_warehouse(session, warehouse)
-        wh.write(session)
-        warehouses.append(wh)
-        wh2 = describe_warehouse(session, warehouse)
-        wh2.weekday = False
-        wh2.write(session)
-        warehouses.append(wh2)
-    return warehouses
 
 
 def convert_time_str(time_str) -> datetime.time:

--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -249,7 +249,7 @@ class Warehouses(Container):
         wh = st.session_state.get("warehouse")
         whfilter = wh.warehouse
         with connection.Connection.get() as conn:
-            all_data, default_schedules = fetch_schedules_with_defaults(conn, whfilter)
+            all_data = fetch_schedules_with_defaults(conn, whfilter)
 
         data = [i for i in all_data if i.weekday and i.name == whfilter]
         data_we = [i for i in all_data if not i.weekday and i.name == whfilter]
@@ -269,9 +269,9 @@ class Warehouses(Container):
             ),
         )
 
-        # If the user has changed the schedules in any way and they are not enabled, give a hint to the
+        # If the user has changed the schedules in any way and the schedules are not already enabled, give a hint to the
         # user that they may want to enable them.
-        if not default_schedules and not is_enabled:
+        if any([ws.last_modified for ws in all_data]) and not is_enabled:
             st.info("Schedules are not running. Check the above box to enable them.")
 
         st.title("Weekdays")

--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -6,6 +6,7 @@ from crud.wh_sched import (
     WarehouseSchedules,
     _WAREHOUSE_SIZE_OPTIONS,
     after_schedule_change,
+    fetch_schedules_with_defaults,
     verify_and_clean,
 )
 from table import build_table, Actions
@@ -16,7 +17,6 @@ from warehouse_utils import (
     time_filter,
     create_callback,
     convert_time_str,
-    populate_initial,
     set_enabled,
 )
 from crud.errors import summarize_error
@@ -248,7 +248,7 @@ class Warehouses(Container):
         wh = st.session_state.get("warehouse")
         whfilter = wh.warehouse
         with connection.Connection.get() as conn:
-            all_data = populate_initial(conn, whfilter)
+            all_data = fetch_schedules_with_defaults(conn, whfilter)
 
         data = [i for i in all_data if i.weekday and i.name == whfilter]
         data_we = [i for i in all_data if not i.weekday and i.name == whfilter]

--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -172,6 +172,7 @@ class Warehouses(Container):
                     if "enabled" in st.session_state
                     else False
                 ),
+                last_modified=datetime.datetime.now(),
             )
         )
         return new_update
@@ -248,7 +249,7 @@ class Warehouses(Container):
         wh = st.session_state.get("warehouse")
         whfilter = wh.warehouse
         with connection.Connection.get() as conn:
-            all_data = fetch_schedules_with_defaults(conn, whfilter)
+            all_data, default_schedules = fetch_schedules_with_defaults(conn, whfilter)
 
         data = [i for i in all_data if i.weekday and i.name == whfilter]
         data_we = [i for i in all_data if not i.weekday and i.name == whfilter]
@@ -267,6 +268,11 @@ class Warehouses(Container):
                 ),
             ),
         )
+
+        # If the user has changed the schedules in any way and they are not enabled, give a hint to the
+        # user that they may want to enable them.
+        if not default_schedules and not is_enabled:
+            st.info("Schedules are not running. Check the above box to enable them.")
 
         st.title("Weekdays")
         cbs = Actions(

--- a/bootstrap/011_warehouse_schedules.sql
+++ b/bootstrap/011_warehouse_schedules.sql
@@ -152,7 +152,7 @@ from crud.wh_sched import WarehouseSchedules, after_schedule_change, merge_new_s
 def create_warehouse_schedule(bare_session, name: str, size: str, start: datetime.time, finish: datetime.time, weekday: bool, suspend_minutes: int, autoscale_mode: str, autoscale_min: int, autoscale_max: int, auto_resume: bool, comment: str):
     with transaction(bare_session) as session:
         # Read the current schedules
-        current_scheds = WarehouseSchedules.find_all(session, name, weekday)
+        current_scheds = WarehouseSchedules.find_all_with_weekday(session, name, weekday)
 
         # Figure out if the schedules are enabled or disabled
         is_enabled = all(s.enabled for s in current_scheds) if len(current_scheds) > 0 else False
@@ -261,7 +261,7 @@ def update_warehouse_schedule(bare_session, name: str, start: datetime.time, fin
         ))
 
         # Read the current schedules
-        schedules = WarehouseSchedules.find_all(session, name, new_schedule.weekday)
+        schedules = WarehouseSchedules.find_all_with_weekday(session, name, new_schedule.weekday)
 
         # Update the WarehouseSchedule instance for this warehouse
         schedules_needing_update = update_existing_schedule(old_schedule.id_val, new_schedule, schedules)

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -74,6 +74,8 @@ call internal_python.create_table('WAREHOUSE_SCHEDULES');
 call internal_python.create_table('WAREHOUSE_ALTER_STATEMENTS');
 call internal.CREATE_WAREHOUSE_SCHEDULES_VIEWS();
 
+call INTERNAL.MIGRATE_WHSCHED_TABLE();
+
 -- Populate the list of predefined labels
 call INTERNAL.POPULATE_PREDEFINED_LABELS();
 


### PR DESCRIPTION
If the user has only viewed the warehouse schedules, they will have a row persisted into internal.wh_schedules. However, we want to update that row with the latest state of the warehouse if the user has not enabled the schedule (implying they want it to take effect).

Closes #351