### PR TITLE
In update, load the current value for size and start_at.

### DIFF
--- a/app/ui/warehouses.py
+++ b/app/ui/warehouses.py
@@ -88,15 +88,23 @@ class Warehouses(Container):
         finish_time_filter: List[str] = None,
         is_create=False,
     ):
+        sizes = list(_WAREHOUSE_SIZE_OPTIONS.keys())
+        current_start_at_str = update.start_at.strftime("%I:%M %p")
         size = st.selectbox(
             key="SIZE",
             label="Size",
-            options=list(_WAREHOUSE_SIZE_OPTIONS.keys()),
+            options=sizes,
+            index=sizes.index(update.size),
         )
         start = st.selectbox(
             key="START",
             label="Start",
             options=start_time_filter,
+            index=(
+                start_time_filter.index(current_start_at_str)
+                if current_start_at_str in start_time_filter
+                else 0
+            ),
             disabled=len(start_time_filter) == 1,
         )
         finish = st.selectbox(


### PR DESCRIPTION
Closes #440

Update was annoying in that it always displayed the warehouse size and start_at at index=0, rather than the current value of the schedule. This corrects update() so that it displays the current value. Create() should still pull values from the previous row (the row that you are creating the new schedule from)