### PR TITLE
Parse warehouse_mode as snowflake returns it

### DIFF
--- a/app/crud/test_wh_sched.py
+++ b/app/crud/test_wh_sched.py
@@ -431,3 +431,14 @@ def test_no_pandas_timestamps():
     tup = unwrap_value(pandas.Timestamp.now())
     assert len(tup) == 2
     assert isinstance(tup[1], datetime.datetime)
+
+
+def test_case_insensitive_warehouse_mode():
+    ws = _make_schedule(
+        "COMPUTE_WH",
+        datetime.time(0, 0),
+        datetime.time(23, 59),
+        True,
+        warehouse_mode="STANDARD",
+    )
+    assert ws.warehouse_mode == "Standard"

--- a/app/crud/wh_sched.py
+++ b/app/crud/wh_sched.py
@@ -168,8 +168,9 @@ class WarehouseSchedules(BaseOpsCenterModel):
         if not v:
             raise ValueError("Warehouse mode is required")
         assert isinstance(v, str)
-        assert v in _WAREHOUSE_MODE_OPTIONS
-        return v
+        cleaned = v.title()
+        assert cleaned in _WAREHOUSE_MODE_OPTIONS
+        return cleaned
 
     @root_validator(allow_reuse=True)
     @classmethod


### PR DESCRIPTION
`show warehouses like %s` will return `warehouse_mode` as `STANDARD` or `ECONOMY` which fails our validation logic.

Update our validation to normalize the input before we validate it.