### PR TITLE
Use column_order="name" for all dataframe writes

### DIFF
--- a/app/crud/base.py
+++ b/app/crud/base.py
@@ -44,7 +44,9 @@ class BaseOpsCenterModel(BaseModel):
 
     def write(self, session):
         df = session.create_dataframe([self.to_row()])
-        df.write.mode("append").save_as_table(f"INTERNAL.{self.table_name}")
+        df.write.mode("append").save_as_table(
+            f"INTERNAL.{self.table_name}", column_order="name"
+        )
 
     def get_id(self) -> str:
         """
@@ -97,8 +99,10 @@ class BaseOpsCenterModel(BaseModel):
         :return:
         """
         df = session.create_dataframe([d.to_row() for d in data])
+        # column_order only matters in append mode, but does not fail if it is specified in non-append mode
         df.write.mode("overwrite" if overwrite else "append").save_as_table(
-            f"INTERNAL.{cls.table_name}"
+            f"INTERNAL.{cls.table_name}",
+            column_order="name",
         )
 
     @classmethod

--- a/app/crud/wh_sched.py
+++ b/app/crud/wh_sched.py
@@ -836,7 +836,9 @@ def log_to_table(session: Session, this_run, success, obj):
             )
         ]
     )
-    df.write.mode("append").save_as_table("internal.task_warehouse_schedule")
+    df.write.mode("append").save_as_table(
+        "internal.task_warehouse_schedule", column_order="name"
+    )
 
 
 _WAREHOUSE_SIZE_OPTIONS = {


### PR DESCRIPTION
Without this, the ordinal positions of the columns in the backing table becomes critical. We do not want to guarantee a fixed ordering of columns, but instead want to rely on a given set of column names.

Closes #465