### PR TITLE
Automatically set last_modified when schedules are changed

### DIFF
--- a/app/crud/test_wh_sched.py
+++ b/app/crud/test_wh_sched.py
@@ -442,3 +442,31 @@ def test_case_insensitive_warehouse_mode():
         warehouse_mode="STANDARD",
     )
     assert ws.warehouse_mode == "Standard"
+
+
+def test_last_modified_updated(session):
+    ws = _make_schedule(
+        "COMPUTE_WH",
+        datetime.time(0, 0),
+        datetime.time(23, 59),
+        True,
+    )
+    assert ws.last_modified is None, "last_modified is not set by this test"
+
+    ws.write(session)
+
+    assert ws.last_modified is not None, "writing the schedule should set last_modified"
+
+    ws.last_modified = None
+    ws.update(
+        session,
+        _make_schedule(
+            "COMPUTE_WH",
+            datetime.time(0, 0),
+            datetime.time(23, 59),
+            True,
+            size="Medium",
+        ),
+    )
+
+    assert ws.last_modified is not None, "Update should set last_modified"

--- a/app/crud/wh_sched.py
+++ b/app/crud/wh_sched.py
@@ -110,7 +110,12 @@ class WarehouseSchedules(BaseOpsCenterModel):
             raise ValueError(
                 f"Warehouse schedules have a maximum of {WarehouseSchedules.max_sub_schedules} sub-schedules."
             )
+        self.last_modified = datetime.datetime.now()
         super().write(session)
+
+    def update(self, session: Session, update: "WarehouseSchedules"):
+        update.last_modified = datetime.datetime.now()
+        return super().update(session, update)
 
     @validator("name", allow_reuse=True)
     def verify_name(cls, v):

--- a/app/crud/wh_sched.py
+++ b/app/crud/wh_sched.py
@@ -114,7 +114,10 @@ class WarehouseSchedules(BaseOpsCenterModel):
         super().write(session)
 
     def update(self, session: Session, update: "WarehouseSchedules"):
+        # Set last_modified on `update` to push it to the SQL table
         update.last_modified = datetime.datetime.now()
+        # Then, update `self` to reflect the change to the caller
+        self.last_modified = update.last_modified
         return super().update(session, update)
 
     @validator("name", allow_reuse=True)


### PR DESCRIPTION
This ultimately is a push-down of logic that used to live in Streamlit so that procedures will also benefit from it.