### PR TITLE
V1 bugfixes

### DIFF
--- a/app/crud/test_wh_sched.py
+++ b/app/crud/test_wh_sched.py
@@ -442,3 +442,31 @@ def test_case_insensitive_warehouse_mode():
         warehouse_mode="STANDARD",
     )
     assert ws.warehouse_mode == "Standard"
+
+
+def test_last_modified_updated(session):
+    ws = _make_schedule(
+        "COMPUTE_WH",
+        datetime.time(0, 0),
+        datetime.time(23, 59),
+        True,
+    )
+    assert ws.last_modified is None, "last_modified is not set by this test"
+
+    ws.write(session)
+
+    assert ws.last_modified is not None, "writing the schedule should set last_modified"
+
+    ws.last_modified = None
+    ws.update(
+        session,
+        _make_schedule(
+            "COMPUTE_WH",
+            datetime.time(0, 0),
+            datetime.time(23, 59),
+            True,
+            size="Medium",
+        ),
+    )
+
+    assert ws.last_modified is not None, "Update should set last_modified"

--- a/app/crud/test_wh_sched_task.py
+++ b/app/crud/test_wh_sched_task.py
@@ -64,7 +64,7 @@ def test_basic_task(session, wh_sched_fixture):
         assert len(statements) == 1
         assert "alter warehouse COMPUTE_WH set".lower() in statements[0].lower()
         assert "WAREHOUSE_SIZE = XLARGE".lower() in statements[0].lower()
-        assert "AUTO_SUSPEND = 15".lower() in statements[0].lower()
+        assert "AUTO_SUSPEND = 900".lower() in statements[0].lower()
 
         # Verify the task result was logged into the internal table
         assert len(wh_sched_fixture.task_log) == 1
@@ -159,7 +159,7 @@ def test_basic_weekend_task(session, wh_sched_fixture):
         assert len(statements) == 1
         assert "alter warehouse COMPUTE_WH set".lower() in statements[0].lower()
         assert "WAREHOUSE_SIZE = XSMALL".lower() in statements[0].lower()
-        assert "AUTO_SUSPEND = 1".lower() in statements[0].lower()
+        assert "AUTO_SUSPEND = 60".lower() in statements[0].lower()
 
         # Verify the task result was logged into the internal table
         assert len(wh_sched_fixture.task_log) == 1
@@ -202,7 +202,7 @@ def test_basic_weekday_task(session, wh_sched_fixture):
         assert len(statements) == 1
         assert "alter warehouse COMPUTE_WH set".lower() in statements[0].lower()
         assert "WAREHOUSE_SIZE = SMALL".lower() in statements[0].lower()
-        assert "AUTO_SUSPEND = 1".lower() in statements[0].lower()
+        assert "AUTO_SUSPEND = 60".lower() in statements[0].lower()
 
         # Verify the task result was logged into the internal table
         assert len(wh_sched_fixture.task_log) == 1
@@ -351,7 +351,7 @@ def test_missed_task_execution(session, wh_sched_fixture):
         assert len(statements) == 1
         assert "alter warehouse COMPUTE_WH set".lower() in statements[0].lower()
         assert "WAREHOUSE_SIZE = SMALL".lower() in statements[0].lower()
-        assert "AUTO_SUSPEND = 15".lower() in statements[0].lower()
+        assert "AUTO_SUSPEND = 900".lower() in statements[0].lower()
 
         # Verify the task result was logged into the internal table
         assert len(wh_sched_fixture.task_log) == 1

--- a/app/crud/wh_sched.py
+++ b/app/crud/wh_sched.py
@@ -110,7 +110,15 @@ class WarehouseSchedules(BaseOpsCenterModel):
             raise ValueError(
                 f"Warehouse schedules have a maximum of {WarehouseSchedules.max_sub_schedules} sub-schedules."
             )
+        self.last_modified = datetime.datetime.now()
         super().write(session)
+
+    def update(self, session: Session, update: "WarehouseSchedules"):
+        # Set last_modified on `update` to push it to the SQL table
+        update.last_modified = datetime.datetime.now()
+        # Then, update `self` to reflect the change to the caller
+        self.last_modified = update.last_modified
+        return super().update(session, update)
 
     @validator("name", allow_reuse=True)
     def verify_name(cls, v):

--- a/app/crud/wh_sched.py
+++ b/app/crud/wh_sched.py
@@ -505,7 +505,7 @@ def generate_alter_from_schedule(
         changes.append("WAREHOUSE_TYPE = SNOWPARK-OPTIMIZED")
     else:
         changes.append("WAREHOUSE_TYPE = STANDARD")
-    changes.append(f"AUTO_SUSPEND = {schedule.suspend_minutes}")
+    changes.append(f"AUTO_SUSPEND = {schedule.suspend_minutes * 60}")
     changes.append(f"AUTO_RESUME = {schedule.resume}")
     if not is_standard:
         changes.append(f"MIN_CLUSTER_COUNT = {schedule.scale_min}")
@@ -541,7 +541,7 @@ def compare_warehouses(
         if "Snowpark" not in warehouse_next.size and "Snowpark" in warehouse_now.size:
             changes.append("WAREHOUSE_TYPE = STANDARD")
     if warehouse_now.suspend_minutes != warehouse_next.suspend_minutes:
-        changes.append(f"AUTO_SUSPEND = {warehouse_next.suspend_minutes}")
+        changes.append(f"AUTO_SUSPEND = {warehouse_next.suspend_minutes * 60}")
     if warehouse_now.resume != warehouse_next.resume:
         changes.append(f"AUTO_RESUME = {warehouse_next.resume}")
     if warehouse_now.scale_min != warehouse_next.scale_min and not is_standard:

--- a/test/unit/test_warehouse_schedules.py
+++ b/test/unit/test_warehouse_schedules.py
@@ -68,8 +68,8 @@ def test_basic_warehouse_schedule(conn, timestamp_string):
             # Set up internal state normally handled in admin.finalize_setup()
             _ensure_tables_created(cnx)
 
-            # Create default schedule with X-Small for this warehouse
-            sql = f"call ADMIN.CREATE_WAREHOUSE_SCHEDULE('{wh_name}', 'X-Small', '00:00', '23:59', TRUE, 0, 'Standard', 0, 0, TRUE, NULL)"
+            # Create the default schedule
+            sql = f"call ADMIN.CREATE_DEFAULT_SCHEDULES('{wh_name}')"
             _ = cur.execute(sql).fetchone()
 
             # After noon, change to Small
@@ -124,7 +124,8 @@ def test_alternate_timezone(conn, timestamp_string):
             # Set up internal state normally handled in admin.finalize_setup()
             _ensure_tables_created(cnx)
 
-            sql = f"call ADMIN.CREATE_WAREHOUSE_SCHEDULE('{wh_name}', 'X-Small', '00:00', '23:59', TRUE, 0, 'Standard', 0, 0, TRUE, NULL)"
+            # Create the default schedule
+            sql = f"call ADMIN.CREATE_DEFAULT_SCHEDULES('{wh_name}')"
             _ = cur.execute(sql).fetchone()
 
             # After noon, change to Small
@@ -192,7 +193,7 @@ def test_from_london(conn, timestamp_string):
             _ensure_tables_created(cnx)
 
             # Create default schedule with X-Small for this warehouse
-            sql = f"call ADMIN.CREATE_WAREHOUSE_SCHEDULE('{wh_name}', 'X-Small', '0:00', '23:59', TRUE, 0, 'Standard', 0, 0, TRUE, NULL)"
+            sql = f"call ADMIN.CREATE_DEFAULT_SCHEDULES('{wh_name}')"
             _ = cur.execute(sql).fetchone()
 
             # After noon, change to Small
@@ -204,10 +205,6 @@ def test_from_london(conn, timestamp_string):
             _ = cur.execute(sql).fetchone()
 
             # Weekend nights run ETL
-            sql = f"call ADMIN.CREATE_WAREHOUSE_SCHEDULE('{wh_name}', 'X-Small', '0:00', '23:59', FALSE, 0, 'Standard', 0, 0, TRUE, NULL)"
-            _ = cur.execute(sql).fetchone()
-
-            # After noon, change to Small
             sql = f"call ADMIN.CREATE_WAREHOUSE_SCHEDULE('{wh_name}', '2X-Large', '22:00', '23:59', FALSE, 15, 'Standard', 0, 0, TRUE, NULL)"
             _ = cur.execute(sql).fetchone()
 

--- a/test/unit/test_warehouse_schedules.py
+++ b/test/unit/test_warehouse_schedules.py
@@ -245,7 +245,7 @@ def test_from_london(conn, timestamp_string):
                 len(obj["statements"]) == 1
             ), f"Expected an alter warehouse statement: {obj}"
             assert "WAREHOUSE_SIZE = MEDIUM" in obj["statements"][0]
-            assert "AUTO_SUSPEND = 15" in obj["statements"][0]
+            assert "AUTO_SUSPEND = 900" in obj["statements"][0]
 
             # weekday, 17:00 in utc+1
             row = cur.execute(
@@ -262,7 +262,7 @@ def test_from_london(conn, timestamp_string):
             assert "statements" in obj
             assert len(obj["statements"]) == 1
             assert "WAREHOUSE_SIZE = SMALL" in obj["statements"][0]
-            assert "AUTO_SUSPEND = 5" in obj["statements"][0]
+            assert "AUTO_SUSPEND = 300" in obj["statements"][0]
 
             # weekend, 09:00 in utc+1
             row = cur.execute(
@@ -294,7 +294,7 @@ def test_from_london(conn, timestamp_string):
             assert "statements" in obj
             assert len(obj["statements"]) == 1
             assert "WAREHOUSE_SIZE = XXLARGE" in obj["statements"][0]
-            assert "AUTO_SUSPEND = 15" in obj["statements"][0]
+            assert "AUTO_SUSPEND = 900" in obj["statements"][0]
     finally:
         with conn() as cnx, cnx.cursor() as cur:
             _ = cur.execute(f"DROP WAREHOUSE IF EXISTS {wh_name}").fetchone()


### PR DESCRIPTION
Includes 3 bugfixes from main into the `v1` branch (which was branched on the tag `v1.34`)

* Convert minutes back to seconds in warehouse scheduling `ALTER WAREHOUSE` statements
* Automatically set `LAST_MODIFIED` on mutate of schedule
* Stored procedure to create default schedules for a warehouse