### PR TITLE
Missed the sortby on this one invocation.

### DIFF
--- a/bootstrap/011_warehouse_schedules.sql
+++ b/bootstrap/011_warehouse_schedules.sql
@@ -213,7 +213,7 @@ def run_delete(bare_session, name: str, start: datetime.time, finish: datetime.t
             raise Exception(f"Could not find warehouse schedule: {name}, {start}, {finish}, {'weekday' if is_weekday else 'weekend'}")
 
         to_delete = WarehouseSchedules.construct(id_val = row.id_val)
-        current_scheds = WarehouseSchedules.batch_read(session, filter=lambda df: ((df.name == name) & (df.weekday == is_weekday)))
+        current_scheds = WarehouseSchedules.batch_read(session, sortby="start_at", filter=lambda df: ((df.name == name) & (df.weekday == is_weekday)))
         new_scheds = delete_warehouse_schedule(to_delete, current_scheds)
 
         # Delete that schedule, leaving a hole


### PR DESCRIPTION
When we get unlucky and the rows are misordered, it can cause the delete cleanup to fail.

```
Verify failed: Start time must be before finish time\\nid_val=\'d730ad7d6fa6400fb7168f28364dce6d\' name=\'integration_tests\' start_at=datetime.time(17, 0) finish_at=datetime.time(8, 0) size=\'Medium\' suspend_minutes=1 resume=True scale_min=1 scale_max=1 warehouse_mode=\'Standard\' comment=None weekday=True day=None enabled=True last_modified=NaT
```

