### PR TITLE
[v1] Move the warehouse schedules table creation out of python (#482)

### DIFF
--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -69,11 +69,6 @@ CREATE OR REPLACE TASK TASKS.SFUSER_MAINTENANCE
 -- create the query_hash functions in TOOLS
 call INTERNAL.ENABLE_QUERY_HASH();
 
--- Create the tables defined in python
-call internal_python.create_table('WAREHOUSE_SCHEDULES');
-call internal_python.create_table('WAREHOUSE_ALTER_STATEMENTS');
-call internal.CREATE_WAREHOUSE_SCHEDULES_VIEWS();
-
 call INTERNAL.MIGRATE_WHSCHED_TABLE();
 
 -- Populate the list of predefined labels


### PR DESCRIPTION
Cherry-pick of #482 into `v1`

We moved the table creation into finalize_setup() because we cannot call a python procedure during the native app setup script. However, this created a different problem that this procedure needs to be called (e.g. the UI opened) before the user is able to see/use the catalog views.

Lift the table/view creation out of python and put it into SQL again.