### PR TITLE
Ensure that query monitors with duplicate conditions eventually fire

### DIFF
--- a/bootstrap/007_probes.sql
+++ b/bootstrap/007_probes.sql
@@ -125,6 +125,11 @@ BEGIN
     -- TODO: find a way to improve this so we're not double querying probes.
     -- We do it here so we don't have to transport objects from queries to sql text but it means
     -- there is a slight chance of seeing different actions for the probe between the first step and the second.
+    --
+    -- The actions CTE is doing two-levels of filtering to ensure each probe fires exactly one per matched query.
+    -- The addition clauses on top of the CONDITION in the case statements ensure probes with duplicate conditions
+    -- will each match. The final NOT IN clause of the where condition for the CTE will ensure that we don't re-trigger
+    -- the same probe again for the same query when multiple probes exist with the same condition.
     let s string := $$
     with
     users as (
@@ -134,12 +139,12 @@ BEGIN
         select * from internal.probes where cancel or notify_writer or length(notify_other) > 3
     ),
     actions as (
-    SELECT current_timestamp() as probe_time, query_id, user_name, query_text, warehouse_name, start_time, case $$;
+    SELECT current_timestamp() as probe_time, qh.query_id, user_name, query_text, warehouse_name, start_time, case $$;
     let found boolean := false;
     let probes cursor for select name, condition from internal.probes;
     for probe in probes do
         found := true;
-        s := s || '\n\t when ' || probe.condition || $$ then '$$ || probe.name || $$' $$;
+        s := s || '\n\t when ' || probe.condition || $$ and (actions.probe_name != '$$ || probe.name || $$' or actions.probe_name is null) then '$$ || probe.name || $$' $$;
     end for;
 
     if (not found) then
@@ -147,8 +152,10 @@ BEGIN
     end if;
     s := s || $$
     else null end as probe_to_execute
-    from table(SNOWFLAKE.INFORMATION_SCHEMA.QUERY_HISTORY(CURRENT_TIMESTAMP()))
-    where session_id <> current_session()
+    from table(SNOWFLAKE.INFORMATION_SCHEMA.QUERY_HISTORY(CURRENT_TIMESTAMP())) as qh
+    left outer join internal.probe_actions as actions on qh.query_id = actions.query_id
+    where session_id <> current_session() and
+        (probe_to_execute, qh.query_id) not in (select probe_name, query_id from internal.probe_actions)
     ),
     items as (
     select
@@ -165,7 +172,6 @@ BEGIN
     join probes p on a.probe_to_execute = p.name
     left join users u on a.user_name = u.name
     where probe_to_execute is not null
-    and (probe_to_execute, query_id) not in (select probe_name, query_id from internal.probe_actions)
     )
     select probe_time, probe_name, query_id, action_taken, user_name, warehouse_name, start_time, query_text from items
     $$;


### PR DESCRIPTION
OpsCenter allows multiple query monitors to exist that have the same condition. A bug was identified by Jacques in which, after the first query monitor "fires", the subsequent query monitors duplicating the condition of the first QM, never fire. The expectation is that on the next "run" of the query monitor task execution, subsequent query monitors will "fire".

I solved this by lifting the logic to check the internal.probe_actions table (which records if a QM has already fired for a query) into a scalar UDF and embedded that in the case-statement which matches a query to a Query Monitor. This seemed like the "easiest" solution (but not necessarily the most elegant solution) -- this felt like the correct trade-off to me (simplicity over complexity). WRT performance, my expectation is that Snowflake would pull the partition of probe_actions into memory once (containing recent rows) and subsequent calls over the UDF would be "fast" (but I have not spend time to verify that is happening).