### PR TITLE
Add procedures to describe and change cost-related settings

### DIFF
--- a/app/crud/settings.py
+++ b/app/crud/settings.py
@@ -1,0 +1,78 @@
+import pytz
+from pydantic import (
+    root_validator,
+)
+from typing import ClassVar, Union, Dict
+from .base import BaseOpsCenterModel, transaction
+
+
+class Setting(BaseOpsCenterModel):
+    table_name: ClassVar[str] = "SETTINGS"
+    # The mapping of setting key and expected type known by OpsCenter
+    known_settings: ClassVar[Dict[str, type]] = {
+        "default_timezone": str,
+        "storage_cost": float,
+        "serverless_credit_cost": float,
+        "compute_credit_cost": float,
+    }
+
+    key: str
+    value: Union[str, float]
+
+    def get_id_col(self) -> str:
+        return "key"
+
+    def get_id(self) -> str:
+        return self.key
+
+    def delete(self, session):
+        raise NotImplementedError("Delete is not supported for settings")
+
+    def write(self, session):
+        with transaction(session) as txn:
+            txn.sql(
+                "call internal.set_config(?, ?)", params=(self.key, self.value)
+            ).collect()
+
+    @root_validator(allow_reuse=True)
+    @classmethod
+    def validate_value(cls, values) -> "Setting":
+        # Validate a key was given
+        key = values.get("key", None)
+        assert key, "Settings key cannot be null"
+        assert key in cls.known_settings, f"Unknown setting {key}"
+
+        # Pydantic gives us a dict[str, str], we have to check the type conversion ourselves because
+        # we can't access
+        v = values.get("value", None)
+        assert v, "Settings value cannot be null"
+
+        expected_type = cls.known_settings[key]
+        try:
+            v = expected_type(v)
+        except ValueError:
+            pass
+
+        assert (
+            type(v) == expected_type
+        ), f"Expected {expected_type.__name__} for {key} (got {type(v).__name__})"
+
+        if key == "default_timezone":
+            # Check the timezone after we've validated that we have the expected value type
+            cls.verify_timezone(v)
+            assert (
+                values.get("value") in pytz.all_timezones
+            ), f"Unknown timezone {values.get('value')}"
+        elif key in ["storage_cost", "serverless_credit_cost", "compute_credit_cost"]:
+            # Make sure we have a sane cost
+            cls.verify_cost(v)
+
+        return values
+
+    @classmethod
+    def verify_timezone(cls, tz: str):
+        assert tz in pytz.all_timezones, f"Unknown timezone {tz}"
+
+    @classmethod
+    def verify_cost(cls, cost: float):
+        assert cost > 0, f"Credit cost must be greater than 0 (got {cost})"

--- a/app/crud/test_settings.py
+++ b/app/crud/test_settings.py
@@ -1,0 +1,88 @@
+import pytest
+from pydantic import ValidationError
+from .settings import Setting
+
+
+def test_none_attrs():
+    with pytest.raises(ValidationError):
+        _ = Setting(
+            key=None,
+            value="asdf",
+        )
+    with pytest.raises(ValidationError):
+        _ = Setting(
+            key="compute_credit_cost",
+            value=None,
+        )
+
+
+def test_unknown_setting():
+    with pytest.raises(ValidationError):
+        _ = Setting(
+            key="some_other_key",
+            value="asdf",
+        )
+
+
+def test_timezone_setting():
+    _ = Setting(
+        key="default_timezone",
+        value="America/Los_Angeles",
+    )
+
+    with pytest.raises(ValidationError):
+        _ = Setting(
+            key="default_timezone",
+            value="America/DoesNotExist",
+        )
+    with pytest.raises(ValidationError):
+        _ = Setting(
+            key="default_timezone",
+            value=1.0,
+        )
+
+
+def test_storage_cost():
+    _ = Setting(
+        key="storage_cost",
+        value=40.0,
+    )
+
+    with pytest.raises(ValidationError):
+        _ = Setting(key="storage_cost", value=-1.0)
+    with pytest.raises(ValidationError):
+        _ = Setting(key="storage_cost", value=0)
+
+
+def test_compute_credit_cost():
+    _ = Setting(
+        key="compute_credit_cost",
+        value=2.0,
+    )
+
+    with pytest.raises(ValidationError):
+        _ = Setting(key="compute_credit_cost", value=-1.0)
+    with pytest.raises(ValidationError):
+        _ = Setting(key="compute_credit_cost", value=0)
+    with pytest.raises(ValidationError):
+        _ = Setting(
+            key="compute_credit_cost",
+            value="asdf",
+        )
+
+
+def test_serverless_credit_cost():
+    _ = Setting(
+        key="serverless_credit_cost",
+        value=3.0,
+    )
+
+    with pytest.raises(ValidationError):
+        _ = Setting(key="serverless_credit_cost", value=-1.0)
+    with pytest.raises(ValidationError):
+        _ = Setting(key="serverless_credit_cost", value=0)
+    with pytest.raises(ValidationError):
+        _ = Setting(
+            key="serverless_credit_cost",
+            value="asdf",
+        )

--- a/bootstrap/050_settings.sql
+++ b/bootstrap/050_settings.sql
@@ -1,0 +1,34 @@
+
+CREATE OR REPLACE PROCEDURE ADMIN.DESCRIBE_SETTING(name text)
+    RETURNS TEXT
+    LANGUAGE SQL
+    EXECUTE AS OWNER
+AS
+BEGIN
+    let res text := '';
+    call internal.get_config(:name) into :res;
+    return res;
+END;
+
+CREATE OR REPLACE PROCEDURE ADMIN.UPDATE_SETTING(name TEXT, value TEXT)
+    RETURNS TEXT
+    LANGUAGE PYTHON
+    RUNTIME_VERSION = "3.10"
+    HANDLER = 'run'
+    PACKAGES = ('snowflake-snowpark-python', 'pydantic')
+    IMPORTS = ('{{stage}}/python/crud.zip')
+    EXECUTE AS OWNER
+AS
+$$
+from crud.base import transaction
+from crud.errors import summarize_error
+from crud.settings import Setting
+def run(bare_session, name: str, value: str):
+    with transaction(bare_session) as session:
+        try:
+            setting = Setting(key=name, value=value)
+            setting.write(session)
+            return ""
+        except Exception as ve:
+            return summarize_error("Failed to update setting", ve)
+$$;

--- a/test/unit/test_settings.py
+++ b/test/unit/test_settings.py
@@ -1,0 +1,88 @@
+import pytest
+
+
+default_settings = {
+    "default_timezone": "America/Los_Angeles",
+    "storage_cost": "40.0",
+    "compute_credit_cost": "2.0",
+    "serverless_credit_cost": "3.0",
+}
+
+
+def update_setting(cursor, key: str, value: str) -> str:
+    row = cursor.execute(
+        "call admin.update_setting(%(key)s, %(value)s)",
+        params={"key": key, "value": value},
+    ).fetchone()
+    return row[0]
+
+
+def describe_setting(cursor, key: str) -> str:
+    row = cursor.execute(
+        "call admin.describe_setting(%(key)s)", params={"key": key}
+    ).fetchone()
+    return row[0]
+
+
+def reset_default_settings(cur):
+    for k, v in default_settings.items():
+        res = update_setting(cur, k, v)
+        assert res == "", f"Saw error updating setting {k} to {v}: {res}"
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("storage_cost", "35.5"),
+        ("compute_credit_cost", "1.75"),
+        ("serverless_credit_cost", "2.75"),
+    ],
+)
+def test_update_costs(conn, key, value):
+    try:
+        with conn() as cnx, cnx.cursor() as cur:
+            result = update_setting(cur, key, value)
+            assert result == "", f"Saw error updating storage cost: {result}"
+
+            actual_val = describe_setting(cur, key)
+            assert actual_val == value
+    finally:
+        with conn() as cnx, cnx.cursor() as cur:
+            reset_default_settings(cur)
+
+
+def test_update_timezone(conn):
+    try:
+        with conn() as cnx, cnx.cursor() as cur:
+            tz = "Europe/London"
+            result = update_setting(cur, "default_timezone", tz)
+            assert result == "", f"Saw error updating timezone: {result}"
+
+            val = describe_setting(cur, "default_timezone")
+            assert val == tz
+    finally:
+        with conn() as cnx, cnx.cursor() as cur:
+            reset_default_settings(cur)
+
+
+def test_update_unknown_setting(conn):
+    with conn() as cnx, cnx.cursor() as cur:
+        result = update_setting(cur, "something fake", "foo")
+        assert result != "", "Should have seen error updating unknown setting"
+
+        actual_val = describe_setting(cur, "something fake")
+        assert actual_val is None
+
+
+@pytest.mark.parametrize(
+    "key,badvalue",
+    [
+        ("storage_cost", "foo"),
+        ("default_timezone", "not a timezone"),
+        ("default_timezone", "15.0"),
+    ],
+)
+def test_update_bad_values(conn, key, badvalue):
+    with conn() as cnx, cnx.cursor() as cur:
+        result = update_setting(cur, key, badvalue)
+        assert result != "", f"Should have seen error updating {key} with {badvalue}"


### PR DESCRIPTION
* Describing a setting is a SQL proc that wraps the internal proc.
* Updating a setting is a python proc which has a stripped-down model as we would for other crud models.

Includes standalone and snowflake-necessary pytests.