### PR TITLE
Include ENABLED for catalog.labels

### DIFF
--- a/bootstrap/004_labels.sql
+++ b/bootstrap/004_labels.sql
@@ -227,7 +227,7 @@ def update_label(session, old_name, name, grp, rank, condition):
     return update_entity(session, 'LABEL', old_name, {'name': name, 'group_name': grp, 'group_rank': rank, 'condition': condition, 'is_dynamic': False, 'label_created_at': datetime.now(), 'label_modified_at': datetime.now()})
 $$;
 
-CREATE OR REPLACE VIEW CATALOG.LABELS AS SELECT * exclude (enabled) FROM INTERNAL.LABELS;
+CREATE OR REPLACE VIEW CATALOG.LABELS AS SELECT * FROM INTERNAL.LABELS;
 
 CREATE OR REPLACE PROCEDURE INTERNAL.POPULATE_PREDEFINED_LABELS()
     RETURNS text


### PR DESCRIPTION
We have two create view statements:
* This one that is executed during install
* The label migration (`INTERNAL.MIGRATE_LABELS_TABLE()`) invoked during admin.finalize_setup()

These two were inconsistent: one excluded the ENABLED column and the other did not.

I previously had made the call that we should continue to include the ENABLED flag even though we don't currently use it. So, we will make sure that the ENABLED flag is present in both create view statements.