### PR TITLE
Add procedures for remaining "settings" 

### DIFF
--- a/app/crud/tasks.py
+++ b/app/crud/tasks.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel, validator
+from typing import ClassVar, Tuple
+
+
+class Task(BaseModel):
+    known_tasks: ClassVar[Tuple[str]] = (
+        "QUERY_HISTORY_MAINTENANCE",
+        "WAREHOUSE_EVENTS_MAINTENANCE",
+        "SFUSER_MAINTENANCE",
+        "USER_LIMITS_MAINTENANCE",
+    )
+
+    task_name: str
+
+    def enable(self, session):
+        session.sql(f"ALTER TASK TASKS.{self.task_name} RESUME").collect()
+
+    def disable(self, session):
+        session.sql(f"ALTER TASK TASKS.{self.task_name} SUSPEND").collect()
+
+    @validator("task_name", allow_reuse=True)
+    def validate_name(cls, value: str) -> str:
+        assert isinstance(value, str), "Task name must be a string"
+        # Normalize to uppercase and remove leading/trailing whitespace
+        value = value.strip().upper()
+        assert (
+            value in cls.known_tasks
+        ), f"Unknown task {value}, known tasks are {cls.known_tasks}"
+        return value

--- a/app/crud/test_tasks.py
+++ b/app/crud/test_tasks.py
@@ -21,14 +21,14 @@ def test_task_enable(session: MockSession, name: str):
     expected_name = name.strip().lower()
     assert len(session._sql) == 1, "Expected 1 sql statement"
     assert (
-        session._sql[0].lower() == f"alter task {expected_name} resume"
+        session._sql[0].lower() == f"alter task tasks.{expected_name} resume"
     ), "Unexpected task enable query"
 
     task.disable(session)
 
     assert len(session._sql) == 2, "Expected 2 sql statements"
     assert (
-        session._sql[1].lower() == f"alter task {expected_name} suspend"
+        session._sql[1].lower() == f"alter task tasks.{expected_name} suspend"
     ), "Unexpected task disable query"
 
 

--- a/app/crud/test_tasks.py
+++ b/app/crud/test_tasks.py
@@ -1,0 +1,37 @@
+import pytest
+from pydantic import ValidationError
+from .conftest import MockSession
+from .tasks import Task
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        ("QUERY_HISTORY_MAINTENANCE"),
+        ("query_history_maintenance"),
+        ("WaREHouse_EVENTS_maintenance "),
+        ("SFUSER_MAINTENANCE"),
+        ("USER_LIMITS_MAINTENANCE"),
+    ],
+)
+def test_task_enable(session: MockSession, name: str):
+    task = Task(task_name=name)
+    task.enable(session)
+
+    expected_name = name.strip().lower()
+    assert len(session._sql) == 1, "Expected 1 sql statement"
+    assert (
+        session._sql[0].lower() == f"alter task {expected_name} resume"
+    ), "Unexpected task enable query"
+
+    task.disable(session)
+
+    assert len(session._sql) == 2, "Expected 2 sql statements"
+    assert (
+        session._sql[1].lower() == f"alter task {expected_name} suspend"
+    ), "Unexpected task disable query"
+
+
+def test_unknown_task(session: MockSession):
+    with pytest.raises(ValidationError):
+        _ = Task(task_name="UNKNOWN_TASK")

--- a/bootstrap/050_settings.sql
+++ b/bootstrap/050_settings.sql
@@ -32,3 +32,115 @@ def run(bare_session, name: str, value: str):
         except Exception as ve:
             return summarize_error("Failed to update setting", ve)
 $$;
+
+CREATE OR REPLACE PROCEDURE ADMIN.ENABLE_TASK(name TEXT)
+    RETURNS TEXT
+    LANGUAGE PYTHON
+    RUNTIME_VERSION = "3.10"
+    HANDLER = 'run'
+    PACKAGES = ('snowflake-snowpark-python', 'pydantic')
+    IMPORTS = ('{{stage}}/python/crud.zip')
+    EXECUTE AS OWNER
+AS
+$$
+from crud.errors import summarize_error
+from crud.tasks import Task
+def run(session, name: str):
+    try:
+        task = Task(task_name=name)
+        task.enable(session)
+        return ""
+    except Exception as e:
+        return summarize_error("Unable to enable task", e)
+$$;
+
+CREATE OR REPLACE PROCEDURE ADMIN.DISABLE_TASK(name TEXT)
+    RETURNS TEXT
+    LANGUAGE PYTHON
+    RUNTIME_VERSION = "3.10"
+    HANDLER = 'run'
+    PACKAGES = ('snowflake-snowpark-python', 'pydantic')
+    IMPORTS = ('{{stage}}/python/crud.zip')
+    EXECUTE AS OWNER
+AS
+$$
+from crud.errors import summarize_error
+from crud.tasks import Task
+def run(session, name: str):
+    try:
+        task = Task(task_name=name)
+        task.disable(session)
+        return ""
+    except Exception as e:
+        return summarize_error("Unable to disable task", e)
+$$;
+
+CREATE OR REPLACE PROCEDURE ADMIN.ENABLE_DIAGNOSTIC_INSTRUCTIONS()
+    RETURNS TEXT
+    LANGUAGE SQL
+    EXECUTE AS OWNER
+AS
+BEGIN
+    let db text := (select current_database());
+    let message text := $$
+If you haven't already configured an event table for your account, follow these steps:
+
+# Enable Event Table
+
+These commands will create an event table and set it as the default event
+table for your account. Be sure to include use a database and schema that exists in your account.
+
+-- Double check that there is no event table already set for your account before proceeding!
+SHOW PARAMETERS LIKE 'EVENT_TABLE' IN ACCOUNT;
+
+-- Create a database
+CREATE DATABASE my_database;
+
+-- Create the event table in that database
+CREATE EVENT TABLE my_database.public.my_events;
+
+-- Set this event table as the default for your account
+ALTER ACCOUNT SET EVENT_TABLE = my_database.public.my_events;
+
+You can also follow the Snowflake instructions https://docs.snowflake.com/en/developer-guide/logging-tracing/event-table-setting-up to
+set up an event table if you prefer.
+
+# Enable Diagnostic Sharing with Sundeck for OpsCenter
+
+Sharing diagnostics with Sundeck helps us know when users are experiencing any errors in OpsCenter
+so we can fix them as soon as possible. To enable this, please run the following:
+
+ALTER APPLICATION $$ || db || $$ SET SHARE_EVENTS_WITH_PROVIDER = true;
+$$;
+    return message;
+END;
+
+CREATE OR REPLACE PROCEDURE ADMIN.RELOAD_QUERY_HISTORY()
+    RETURNS TEXT
+    LANGUAGE SQL
+    COMMENT = "Reloads the materialized query history and warehouse events data from your Snowflake ACCOUNT_USAGE database."
+    EXECUTE AS OWNER
+AS
+BEGIN
+    SYSTEM$LOG_INFO("Reloading query history and warehouse events data");
+    truncate table internal.task_query_history;
+    truncate table internal.task_warehouse_events;
+    truncate table internal_reporting_mv.cluster_and_warehouse_sessions_complete_and_daily;
+    truncate table internal_reporting_mv.query_history_complete_and_daily;
+    call internal.refresh_warehouse_events(true);
+    call internal.refresh_queries(true);
+    return "";
+END;
+
+CREATE OR REPLACE PROCEDURE ADMIN.RELOAD_PRECONFIGURED_DATA()
+    RETURNS TEXT
+    LANGUAGE SQL
+    COMMENT = "Recreates the Query Monitors and Labels that are included with OpsCenter without overriding any customizations you have made."
+    EXECUTE AS OWNER
+AS
+BEGIN
+    SYSTEM$LOG_INFO("Reloading preconfigured data");
+    call internal.merge_predefined_probes();
+    call internal.merge_predefined_labels();
+    return "";
+END;

--- a/bootstrap/050_settings.sql
+++ b/bootstrap/050_settings.sql
@@ -122,14 +122,14 @@ CREATE OR REPLACE PROCEDURE ADMIN.RELOAD_QUERY_HISTORY()
     EXECUTE AS OWNER
 AS
 BEGIN
-    SYSTEM$LOG_INFO("Reloading query history and warehouse events data");
+    SYSTEM$LOG_INFO('Reloading query history and warehouse events data');
     truncate table internal.task_query_history;
     truncate table internal.task_warehouse_events;
     truncate table internal_reporting_mv.cluster_and_warehouse_sessions_complete_and_daily;
     truncate table internal_reporting_mv.query_history_complete_and_daily;
     call internal.refresh_warehouse_events(true);
     call internal.refresh_queries(true);
-    return "";
+    return '';
 END;
 
 CREATE OR REPLACE PROCEDURE ADMIN.RELOAD_PRECONFIGURED_DATA()
@@ -139,8 +139,8 @@ CREATE OR REPLACE PROCEDURE ADMIN.RELOAD_PRECONFIGURED_DATA()
     EXECUTE AS OWNER
 AS
 BEGIN
-    SYSTEM$LOG_INFO("Reloading preconfigured data");
+    SYSTEM$LOG_INFO('Reloading preconfigured data');
     call internal.merge_predefined_probes();
     call internal.merge_predefined_labels();
-    return "";
+    return '';
 END;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,6 +20,23 @@ def pytest_addoption(parser):
         default="opscenter",
         help="Connection profile name as specified in ~/.snowsql/config",
     )
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow/expensive tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow or expensive to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
 
 
 # Returns value of --profile argument

--- a/test/unit/test_settings.py
+++ b/test/unit/test_settings.py
@@ -171,15 +171,19 @@ def test_reload_query_history(conn):
         row = cur.execute(
             "call internal.get_config('QUERY_HISTORY_MAINTENANCE')"
         ).fetchone()
+        assert row[0] is not None, "Expected QUERY_HISTORY_MAINTENANCE time to be set"
         assert (
-            row[0] > orig_qh_refresh
+            datetime.datetime.strptime(row[0], datetime_format) > orig_qh_refresh
         ), "Expected QUERY_HISTORY_MAINTENANCE time to be updated"
 
         row = cur.execute(
             "call internal.get_config('WAREHOUSE_EVENTS_MAINTENANCE')"
         ).fetchone()
         assert (
-            row[0] > orig_wh_refresh
+            row[0] is not None
+        ), "Expected WAREHOUSE_EVENTS_MAINTENANCE time to be set"
+        assert (
+            datetime.datetime.strptime(row[0], datetime_format) > orig_wh_refresh
         ), "Expected WAREHOUSE_EVENTS_MAINTENANCE time to be updated"
 
 


### PR DESCRIPTION
* Manages Snowflake tasks via Python, exposing simple ENABLE_TASK/DISABLE_TASK procedures
* SQL Proc for instructions to enable diagnostics (I wanted to send back markdown but deploys fail with the triple backtick for codeblocks -- deferred until we want to do something in a UI with this output).
* SQL wrappers around resetting QM&L's and QH/WEH data (does not address the fact that `internal.merge_predefined_labels()` did not work for me -- I have another issue already open for this)
* Python crud unit tests for the tasks
* Snowflake+Python tests for everything
* * The qh/weh data reset is hidden behind a disabled-by-default marker because it is costly/slow.