### PR TITLE
Better validation error messages for warehouse schedules

### DIFF
--- a/app/crud/test_wh_sched.py
+++ b/app/crud/test_wh_sched.py
@@ -3,6 +3,7 @@ import datetime
 import pandas
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 from typing import List
 from unittest.mock import patch
 from . import wh_sched
@@ -89,8 +90,18 @@ def test_basic_wh_sched():
 
 def test_bad_size_wh_sched():
     test_wh_sched = _get_wh_sched(size="Foo")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError) as info:
         _ = WarehouseSchedules.parse_obj(test_wh_sched)
+    # Check that we have a sane error message in the exception
+    assert "Unknown warehouse size" in str(info.value)
+
+
+def test_bad_mode():
+    test_wh_sched = _get_wh_sched(warehouse_mode="Foo")
+    with pytest.raises(ValidationError) as info:
+        _ = WarehouseSchedules.parse_obj(test_wh_sched)
+    # Check that we have a sane error message in the exception
+    assert "Unknown warehouse mode" in str(info.value)
 
 
 def test_bad_times_sched():
@@ -106,8 +117,13 @@ def test_bad_times_sched():
 
 def test_bad_scales():
     test_wh_sched = _get_wh_sched(scale_min=10)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as info:
         _ = WarehouseSchedules.parse_obj(test_wh_sched)
+
+    test_wh_sched = _get_wh_sched(scale_max=15)
+    with pytest.raises(ValueError) as info:
+        _ = WarehouseSchedules.parse_obj(test_wh_sched)
+    assert "be between 0 and 10" in str(info.value)
 
 
 def test_streamlit_values_without_autoscaling():

--- a/app/crud/wh_sched.py
+++ b/app/crud/wh_sched.py
@@ -144,8 +144,8 @@ class WarehouseSchedules(BaseOpsCenterModel):
     def verify_size(cls, v):
         if not v:
             raise ValueError("Size is required")
-        assert isinstance(v, str)
-        assert v in _WAREHOUSE_SIZE_OPTIONS.keys()
+        assert isinstance(v, str), "Warehouse size should be a string"
+        assert v in _WAREHOUSE_SIZE_OPTIONS.keys(), f"Unknown warehouse size '{v}'"
         return v
 
     @validator("suspend_minutes", allow_reuse=True)
@@ -153,7 +153,7 @@ class WarehouseSchedules(BaseOpsCenterModel):
         if v is None:
             raise ValueError("Suspend minutes is required")
         assert isinstance(v, int)
-        assert v >= 0
+        assert v >= 0, "Suspend minutes must be a positive integer"
         return v
 
     @validator("resume", "weekday", "enabled", allow_reuse=True)
@@ -168,7 +168,9 @@ class WarehouseSchedules(BaseOpsCenterModel):
         if v is None:
             raise ValueError("Scale is required")
         assert isinstance(v, int)
-        assert cls.max_cluster_size >= v >= 0
+        assert (
+            cls.max_cluster_size >= v >= 0
+        ), "Scale must be between 0 and 10, inclusive"
         return v
 
     @validator("warehouse_mode", allow_reuse=True)
@@ -177,7 +179,7 @@ class WarehouseSchedules(BaseOpsCenterModel):
             raise ValueError("Warehouse mode is required")
         assert isinstance(v, str)
         cleaned = v.title()
-        assert cleaned in _WAREHOUSE_MODE_OPTIONS
+        assert cleaned in _WAREHOUSE_MODE_OPTIONS, f"Unknown warehouse mode '{cleaned}'"
         return cleaned
 
     @root_validator(allow_reuse=True)


### PR DESCRIPTION
Found a few places where we did not include an error message on the assert statement. These are traveling to the user, so they should be terse yet specific.