### PR TITLE
Fix any duplicate labels that were caused before #496 (#503)

### DIFF
--- a/app/crud/labels.py
+++ b/app/crud/labels.py
@@ -25,11 +25,14 @@ class Label(BaseOpsCenterModel):
     enabled: bool = True
     label_modified_at: datetime.datetime  # todo should this have a default?
     is_dynamic: bool = False
+    label_id: str
 
     def get_id_col(self) -> str:
+        # todo update after we add the id column
         return "name" if self.name else "group_name"
 
     def get_id(self) -> str:
+        # todo update after we add the id column
         return self.name if self.name else self.group_name
 
     def delete(self, session):
@@ -239,6 +242,7 @@ class PredefinedLabel(Label):
             columns={col_name: col_name.lower() for col_name in df.axes[1]},
             inplace=True,
         )
+        df["label_id"] = "predefined"
         for row in df.to_dict(orient="records"):
             # Validate each predefined label
             _ = Label.parse_obj(row)

--- a/app/crud/test_label.py
+++ b/app/crud/test_label.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import math
 import pandas as pd
 from .labels import Label
+from uuid import uuid4
 
 
 def _get_label(
@@ -19,6 +20,7 @@ def _get_label(
         label_created_at=datetime.now(),
         enabled=True,
         is_dynamic=dynamic,
+        label_id=str(uuid4()),
     )
     if dynamic:
         del d["name"]
@@ -119,7 +121,7 @@ def test_create_table(session):
         """create table if not exists internal.labels
         (name string null, group_name string null, group_rank number null,
         label_created_at timestamp, condition string, enabled boolean, label_modified_at timestamp,
-        is_dynamic boolean)""".split()
+        is_dynamic boolean, label_id string)""".split()
     ), "Expected create table statement, got {}".format(session._sql[0])
     assert (
         session._sql[1].lower()
@@ -138,6 +140,7 @@ def test_from_pandas():
             "enabled": True,
             "label_modified_at": pd.Timestamp("2023-09-20 09:55:43.469000"),
             "is_dynamic": True,
+            "label_id": str(uuid4()),
         }
     )
 

--- a/app/ui/labels.py
+++ b/app/ui/labels.py
@@ -1,6 +1,7 @@
 import datetime
 
 import pydantic
+import uuid
 import streamlit as st
 from connection import Connection
 import session as general_session
@@ -189,6 +190,7 @@ class Label:
                     obj = ModelLabel.parse_obj(
                         {
                             "name": name,
+                            "label_id": str(uuid.uuid4()),
                             "condition": condition,
                             "group_rank": rank,
                             "group_name": group,
@@ -234,6 +236,7 @@ class Label:
                         {
                             "old_name": oldname,
                             "name": name,
+                            "label_id": str(uuid.uuid4()),
                             "condition": condition,
                             "group_rank": rank,
                             "group_name": group,

--- a/bootstrap/091_run_migrations.sql
+++ b/bootstrap/091_run_migrations.sql
@@ -1,0 +1,44 @@
+
+-- Run all migration procedures for INTERNAL tables (not a versioned schema).
+-- Only run procedures that do not rely on access to the SNOWFLAKE database because we may not have access to it yet.
+
+-- Migrate the schema of probes and labels tables
+call INTERNAL.MIGRATE_PROBES_TABLE();
+call INTERNAL.MIGRATE_LABELS_TABLE();
+call INTERNAL.MIGRATE_PREDEFINED_PROBES_TABLE();
+call INTERNAL.MIGRATE_PREDEFINED_LABELS_TABLE();
+call INTERNAL.REMOVE_DUPLICATE_LABELS();
+
+-- create the query_hash functions in TOOLS
+call INTERNAL.ENABLE_QUERY_HASH();
+
+-- Migrate warehouse schedules table
+call INTERNAL.MIGRATE_WHSCHED_TABLE();
+
+-- Populate the list of predefined labels
+call INTERNAL.POPULATE_PREDEFINED_LABELS();
+
+-- Init labels using predefined_labels, if the consumer account has not call INTERNAL.INITIALIZE_LABELS, and it
+-- does not have user-created labels.
+call INTERNAL.INITIALIZE_LABELS();
+
+-- Migrate predefined labels to user's labels if user
+-- 1) does not make any change to predefined label,
+-- 2) and does not create new user label
+-- after last install/upgrade of APP
+-- parameter 7200 (seconds) is the timestamp difference when a predefined label is regarded as an old one.
+call INTERNAL.MIGRATE_PREDEFINED_LABELS(7200);
+
+-- Populate the list of predefined probes
+call INTERNAL.POPULATE_PREDEFINED_PROBES();
+
+-- Init PROBES using predefined_probes, if the consumer account has not call INTERNAL.INITIALIZE_PROBES, and it
+-- does not have user-created probes.
+call INTERNAL.INITIALIZE_PROBES();
+
+-- Migrate predefined probes to user's probes if user
+-- 1) does not make any change to predefined probes,
+-- 2) and does not create new user probe
+-- after last install/upgrade of APP
+-- parameter 7200 (seconds) is the timestamp difference when a predefined probe is regarded as an old one.
+call INTERNAL.MIGRATE_PREDEFINED_PROBES(7200);

--- a/test/unit/test_label_procs.py
+++ b/test/unit/test_label_procs.py
@@ -482,3 +482,104 @@ def test_migrate_predefined_labels(conn, timestamp_string):
 
     sql = "delete from internal.config where KEY = 'LABELS_INITED'"
     run_sql(conn, sql)
+
+
+def test_fixes_duplicate_labels(conn, timestamp_string):
+    # clean up the labels table and predefined_labels table
+    sql = "truncate table internal.labels"
+    assert "successfully" in str(
+        run_sql(conn, sql)
+    ), "SQL output does not match expected result!"
+
+    sql = "truncate table internal.predefined_labels"
+    assert "successfully" in str(
+        run_sql(conn, sql)
+    ), "SQL output does not match expected result!"
+
+    sql = "delete from internal.config where KEY = 'LABELS_INITED'"
+    run_sql(conn, sql)
+
+    # Populate predefined_labels table, make sure we have some predefined_labels
+    sql = "CALL INTERNAL.POPULATE_PREDEFINED_LABELS();"
+    assert run_proc(conn, sql) is None, "Stored procedure did not return NULL value!"
+
+    sql = "select count(*) from internal.PREDEFINED_LABELS"
+    num_predefined_labels = row_count(conn, sql)
+    assert (
+        num_predefined_labels > 0
+    ), f"SQL output {num_predefined_labels} does not match expected result!"
+
+    # Copy the predefined labels into the labels table
+    sql = "call INTERNAL.INITIALIZE_LABELS()"
+    output = str(run_sql(conn, sql))
+    assert "True" in output, "SQL output" + output + " does not match expected result!"
+
+    # verify the number of rows in labels table
+    sql = "select count(*) from internal.LABELS"
+    num_labels = row_count(conn, sql)
+    assert (
+        num_labels == num_predefined_labels
+    ), "Number of user labels did not match predefined labels"
+
+    # Create some grouped labels
+    group_name = generate_unique_name("group", timestamp_string)
+    assert (
+        run_proc(
+            conn,
+            f"call ADMIN.CREATE_LABEL('l1', '{group_name}', 50, 'query_type = \\'SELECT\\'');",
+        )
+        is None
+    ), "did not create grouped label"
+    assert (
+        run_proc(
+            conn,
+            f"call ADMIN.CREATE_LABEL('l2', '{group_name}', 60, 'query_type = \\'INSERT\\'');",
+        )
+        is None
+    ), "did not create grouped label"
+
+    # Insert duplicate grouped labels
+    num_inserts = row_count(
+        conn,
+        "INSERT INTO INTERNAL.LABELS SELECT *,uuid_string() as label_id FROM (select * exclude (label_id) from INTERNAL.LABELS) WHERE GROUP_NAME IS NOT NULL",
+    )
+    assert num_inserts > 0, "Should have created some duplicates"
+
+    # Insert duplicate ungrouped labels
+    num_inserts = row_count(
+        conn,
+        "INSERT INTO INTERNAL.LABELS SELECT *,uuid_string() as label_id FROM (select * exclude (label_id) from INTERNAL.LABELS) WHERE GROUP_NAME IS NULL",
+    )
+    assert num_inserts > 0, "Should have created some duplicates"
+
+    # Call migrate_predefined_labels which should remove any duplicate from internal.labels
+    sql = "call INTERNAL.REMOVE_DUPLICATE_LABELS()"
+    output = run_proc(conn, sql)
+    assert output is None, "failed to remove duplicate labels"
+
+    # Verify migration removed duplicates (num predefined labels + two grouped labels made)
+    num_labels_after_migrate = row_count(conn, "select count(*) from internal.LABELS")
+    assert (
+        num_predefined_labels + 2 == num_labels_after_migrate
+    ), "Duplicate labels should have been removed"
+
+    grp_count = row_count(
+        conn, f"select count(*) from internal.labels where group_name = '{group_name}'"
+    )
+    assert (
+        grp_count == 2
+    ), f"Should have two grouped labels with group name '{group_name}'"
+
+    # Cleanup for the next test
+    sql = "truncate table internal.labels"
+    assert "successfully" in str(
+        run_sql(conn, sql)
+    ), "SQL output does not match expected result!"
+
+    sql = "truncate table internal.predefined_labels"
+    assert "successfully" in str(
+        run_sql(conn, sql)
+    ), "SQL output does not match expected result!"
+
+    sql = "delete from internal.config where KEY = 'LABELS_INITED'"
+    run_sql(conn, sql)


### PR DESCRIPTION
* Fix any duplicate labels that were caused before #496

My fix only prevented future duplicates from being created but didn't address any duplicate labels already in the internal.labels table.

* Comment the script

* Cleanup

* Fix the procedure to properly run in the setup script.

Still not sure why this only caused problems in the setup script (and not on its own). Must be something tricky with the manner in which setup script is called.

I also moved calling this procedure into 004_labels (instead of at the end in 091_migrations) because I think this will prevent the need for us to care later if we still have semi-broken labels.

* Avoid the alter table

* add unique id

* Fix unit test

* fix tests again

* one more time

* fix last test

---------