### PR TITLE
Give a better error if the native app can't find a warehouse.

### DIFF
--- a/app/crud/wh_sched.py
+++ b/app/crud/wh_sched.py
@@ -489,6 +489,10 @@ def verify_and_clean(
 
 def describe_warehouse(session: Session, warehouse: str):
     wh_df = session.sql(f"show warehouses like '{warehouse}'").collect()
+    if len(wh_df) == 0:
+        raise ValueError(
+            "Warehouse '{warehouse}' was not found or permissions are missing."
+        )
     wh_dict = wh_df[0].as_dict()
     return WarehouseSchedules(
         name=warehouse,


### PR DESCRIPTION
Before this fix, the user would see an IndexError.

This might "commonly" happen because:
1. The user did not open the app and grant the 'manage warehouses' permission.
2. They specified a warehouse that doesn't exist.