### PR TITLE
Correct issue where Snowflake skips warehouse suspend completed event…

### DIFF
--- a/bootstrap/015_warehouse_views.sql
+++ b/bootstrap/015_warehouse_views.sql
@@ -19,20 +19,20 @@ EVENTS AS (
             when event_name = 'RESUME_WAREHOUSE' and event_state = 'STARTED' then 1
             when event_name = 'RESUME_CLUSTER' and event_state = 'COMPLETED' then 1
             when event_name = 'SUSPEND_CLUSTER' and event_state = 'COMPLETED' then 2
-            when event_name = 'SUSPEND_WAREHOUSE' and event_state = 'COMPLETED' then 2
+            when event_name = 'SUSPEND_WAREHOUSE' and event_state = 'STARTED' then 2
             else null
         end as SESSION_BEHAVIOR,
         case
             when event_name = 'RESUME_WAREHOUSE' and event_state = 'STARTED' then 1
             when event_name = 'RESUME_CLUSTER' and event_state = 'COMPLETED' then 2
             when event_name = 'SUSPEND_CLUSTER' and event_state = 'COMPLETED' then 3
-            when event_name = 'SUSPEND_WAREHOUSE' and event_state = 'COMPLETED' then 4
+            when event_name = 'SUSPEND_WAREHOUSE' and event_state = 'STARTED' then 4
             else null
         end as EVENT
     FROM ACCOUNT_USAGE.WAREHOUSE_EVENTS_HISTORY
     WHERE (event_name, event_state) IN (
         ('RESUME_WAREHOUSE', 'STARTED'),
-        ('SUSPEND_WAREHOUSE', 'COMPLETED'),
+        ('SUSPEND_WAREHOUSE', 'STARTED'),
         ('RESUME_CLUSTER', 'COMPLETED'),
         ('SUSPEND_CLUSTER', 'COMPLETED')
         )


### PR DESCRIPTION
… message

Our expectation of the event model for warehouse events history was:

1. wh suspend start
1. wh suspend complete
1. wh resume start
1. wh resume complete
1. wh suspend start
1. wh suspend complete
1. etc

It looks like there is a pattern where the sequence of events can be:

1. wh suspend start
1. wh resume start
1. wh resume complete

This patterns skips the “suspend complete” before firing a “resume start”. When analyzing internal data, this seems to happen more rarely in the past few months suggesting that it might have been a bug in Snowflake that was fixed. Nonetheless... let's try to address here since Snowflake doesn't formally document these behaviors.

This issue only impacts warehouse events, not cluster events (which don’t have a start and completed, only a completed). However, it impacts both our derived warehouse_sessions and cluster_sessions because we contextualize each cluster session within it's related warehouse session in our first match recognize to facilitate the generation of a warehouse session id to be used for later joins between warehouse_sessions and cluster_sessions.

Proposing a solution to  use “suspend started” as the end of a warehouse session instead of “suspend completed”