### PR TITLE
More bugfixes on new linking process (#540)

### DIFF
--- a/bootstrap/021_external_functions.sql
+++ b/bootstrap/021_external_functions.sql
@@ -450,21 +450,12 @@ create or replace procedure admin.connect_sundeck(token text)
     execute as owner
 as
 DECLARE
-    -- We could also use the internal.reference_management table for OpsCenter V2, but not clear if there is value in that.
     has_api_integration boolean default (select ARRAY_SIZE(PARSE_JSON(SYSTEM$GET_ALL_REFERENCES('OPSCENTER_API_INTEGRATION'))) > 0);
-    integration_name text default (select 'OPSCENTER_SUNDECK_EXTERNAL_FUNCTIONS');
-    deployment text default (select internal.get_sundeck_deployment());
     error_details text default 'unhandled exception caught.';
 BEGIN
-    -- Make sure OpsCenter has been opened and the API Integration permission has been granted (and created)
+    -- Verify the OPSCENTER_API_INTEGRATION reference has been created
     if (not has_api_integration) then
         return object_construct('details', 'Please open the Native App in Snowflake and approve the permission request to create the API Integration.');
-    end if;
-
-    error_details := 'Failed to compute API integration name.';
-    -- Prevent collisions of api integration name
-    if (deployment != 'prod') then
-        integration_name := (select :integration_name || '_' || current_database());
     end if;
 
     error_details := 'Failed to store Sundeck token.';

--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -1,5 +1,5 @@
 
-CREATE OR REPLACE PROCEDURE admin.finalize_setup_from_service_account(url varchar, web_url varchar)
+CREATE OR REPLACE PROCEDURE admin.finalize_setup_from_service_account(api_integration_ref_id varchar, url varchar, web_url varchar)
 RETURNS varchar
 LANGUAGE sql
 as
@@ -7,9 +7,22 @@ begin
     execute immediate 'create or replace function internal.get_ef_url() returns string as \'\\\'' || url || '\\\'\';';
     execute immediate 'create or replace function internal.get_tenant_url() returns string as \'\\\'' || web_url || '\\\'\';';
 
+    -- Create the task so we can run finalize_setup asynchronously (duplicated in finalize_setup)
+    -- Does not start the task -- the first time the task runs, finalize_setup() will start the task.
+    CREATE OR REPLACE TASK TASKS.UPGRADE_CHECK
+        SCHEDULE = '1440 minute'
+        ALLOW_OVERLAPPING_EXECUTION = FALSE
+        USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "XSMALL"
+        AS
+        CALL ADMIN.UPGRADE_CHECK();
+    grant MONITOR, OPERATE on TASK TASKS.UPGRADE_CHECK to APPLICATION ROLE ADMIN;
+
     call internal.set_config('tenant_url', :web_url);
     call internal.set_config('url', :url);
-    call admin.update_reference('OPSCENTER_API_INTEGRATION', 'ADD', SYSTEM$REFERENCE('API Integration', 'OPSCENTER_API_INTEGRATION', 'persistent', 'usage'));
+
+    -- Bind the given reference ID to the 'OPSCENTER_API_INTEGRATION' reference. Must match the reference in manifest.yml
+    -- differs from v1 in that all external functions are not re-created by update_reference()
+    call admin.update_reference('OPSCENTER_API_INTEGRATION', 'finalize_setup_from_service_account', :api_integration_ref_id);
 end;
 
 CREATE OR REPLACE PROCEDURE admin.upgrade_check()
@@ -19,7 +32,7 @@ as
 begin
     let version varchar;
     call internal.get_config('post_setup') into :version;
-    let setup_version varchar := (select internal.setup_version());
+    let setup_version varchar := (select internal.get_version());
     if (version is null or version <> setup_version) then
         call admin.finalize_setup();
     end if;


### PR DESCRIPTION
(this is the "forwardport" of the v1 changes to main)

* s/setup_version/get_version/
* Adds tasks.upgrade_check creation into admin.finalize_setup_with_service_account()
* Expect system$reference to be called prior to finalize_setup_with_service_account()
* Need to create tasks.upgrade_check in finalize_setup too.

--
Grant permissions on task after creation (#542)