### PR TITLE
Conditionally start USER_LIMITS_MAINTENANCE in admin.setup_external_f…

### DIFF
--- a/bootstrap/021_external_functions.sql
+++ b/bootstrap/021_external_functions.sql
@@ -381,8 +381,8 @@ BEGIN
         show tasks in schema tasks;
         let has_task text := (select any_value("name") from table(result_scan(last_query_id())) where "name" = 'USER_LIMITS_CHECK');
         if (:has_task is not null) then
-            -- If the user is setting up the native app via the Streamlit UI, the task exists but has not been started.
-            -- If the user is setting up the native app via Sundeck, the task does not yet exist and will be started after it is created.
+            -- If the user is setting up the native app via the Streamlit UI, the task exists but has not been started. Need to start it here.
+            -- If the user is setting up the native app via Sundeck, the task does not yet exist. UPGRADE_CHECK() will create it and start it.
             CALL internal.start_user_limits_task();
         end if;
     end;

--- a/bootstrap/021_external_functions.sql
+++ b/bootstrap/021_external_functions.sql
@@ -376,8 +376,16 @@ BEGIN
       INSERT (key, value)
       VALUES (source.key, source.value);
 
-    -- Start the user limits task (we know that Sundeck is linked)
-    CALL internal.start_user_limits_task();
+    -- Start the USER_LIMITS_TASK if the task exists
+    begin
+        show tasks in schema tasks;
+        let has_task text := (select any_value("name") from table(result_scan(last_query_id())) where "name" = 'USER_LIMITS_CHECK');
+        if (:has_task is not null) then
+            -- If the user is setting up the native app via the Streamlit UI, the task exists but has not been started.
+            -- If the user is setting up the native app via Sundeck, the task does not yet exist and will be started after it is created.
+            CALL internal.start_user_limits_task();
+        end if;
+    end;
 END;
 
 CREATE OR REPLACE PROCEDURE admin.setup_sundeck_tenant_url(url string, token string) RETURNS STRING LANGUAGE SQL AS


### PR DESCRIPTION
…unctions

When using the `finalize_setup_from_service_account(..)` code path, we have not yet run `finalize_setup()` which means that the `user_limits_maintenance` task has not been created. Make sure the task exists before we try to start it. For the Sundeck-driven setup path, `UPGRADE_CHECK` will come along and make sure the task gets created and started.

While we have the streamlit UI, we have to support starting the task in this procedure as the API integration callback relies on it to start this task. Else, anyone who naturally comes to the Native App in snowflake will be in a broken state.

This went unnoticed because I rarely fully drop the application (so the task lingers and we don't hit this bug).