### PR TITLE
Restore the call to system$set_reference.

### DIFF
--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -25,8 +25,9 @@ begin
     call internal.set_config('tenant_id', :tenant_id);
 
     -- Bind the given reference ID to the 'OPSCENTER_API_INTEGRATION' reference. Must match the reference in manifest.yml
-    -- differs from v1 in that all external functions are not re-created by update_reference()
-   insert into internal.reference_management (ref_name, operation, ref_or_alias) values ('OPSCENTER_API_INTEGRATION', 'Running external functions setup proc.', :api_integration_ref_id);
+    call admin.update_reference('OPSCENTER_API_INTEGRATION', 'ADD', :api_integration_ref_id);
+
+    -- Save the token if provided
     let ret object;
     if (token is not null) then
         call admin.connect_sundeck(:token) into :ret;


### PR DESCRIPTION
In the review on https://github.com/sundeck-io/OpsCenter/pull/556#discussion_r1494465995, I think I lead you astray Ryan.

`select system$reference` has to be called by a user, but my comment ended up having us drop the call to `select system$set_reference` which is the reason that @vqmarkman was having troubles with notifications.

the `reporting.upgrade_history` view gave the hint:
```
| 2024-03-26 11:05:42.971 -0700 | 2024-03-26 11:06:54.961 -0700 | 7c99b66     | 7c99b66     | (505019) state=42704 msg=Uncaught exception of type 'STATEMENT_ERROR' on line 9 at position 4 : Uncaught exception of type 'STATEMENT_ERROR' on line 3 at position 12 : Reference definition 'OPSCENTER_API_INTEGRATION' is missing a reference association. |
```