### PR TITLE
Nightly e2e cypress tests.

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,69 @@
+name: Nightly OpsCenter Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 5:33am UTC/9:33pm PST
+    - cron: '33 5 * * *'
+
+run-name: Nightly Opcenter Tests
+
+concurrency:
+  group: ci-post-deployment-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  cypress-nightly-tests:
+    runs-on: ubuntu-latest-4-cores
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: 'main'
+          submodules: recursive
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+          cache: "pip"
+      - name: install opscenter dependencies
+        run: |
+          pip install poetry
+          poetry install
+      - name: Get suffix
+        id: shell-command
+        run: echo SUFFIX=$(echo ${GITHUB_HEAD_REF} | sed "s/\./_/g" | sed "s/-/_/g" | sed "s\/\_\g")_${GITHUB_RUN_ID} >> $GITHUB_ENV
+      - name: set config
+        env:
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SUFFIX: ${{ env.SUFFIX }}
+        run: |
+          mkdir $HOME/.snowsql
+          OPSCENTER_DATABASE="DATABASE_CYPRESS_${SUFFIX}" envsubst < deploy/opscenter.config > $HOME/.snowsql/config
+      - name: run deploy
+        run: "poetry run python deploy/devdeploy.py -p opscenter"
+      - name: run streamlit
+        run: "poetry run streamlit run app/ui/Home.py --browser.gatherUsageStats false  &"
+      - name: Cypress run
+        uses: cypress-io/github-action@v6
+        env:
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+        with:
+          start: yarn run cypress
+          browser: chrome
+          headless: true
+          record: false
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-artifacts
+          path: |
+            cypress/videos/
+            cypress/screenshots/
+      - name: remove SQL objects
+        run: "poetry run python deploy/cypress_teardown.py -p opscenter"
+      - name: remove SQL objects in failure
+        if: failure()
+        run: "poetry run python deploy/cypress_teardown.py -p opscenter"


### PR DESCRIPTION
Decided to temporarily add a separate nightly run of cypress tests off the latest main branch with devdeploy.py (and not deploy.py)

Successful run of this workflow is [here](https://github.com/vqmarkman/OpsCenter/actions/runs/8462980728/job/23185154857) 

The reason I went with devdeploy.py: 

After I successfully deployed the app in my account with deploy.py (semi real deployment) I realized  (a)  native app very slow to start up and load pages (b) I will need to re-implement login to Snowflake in order to start the app as it can only be started from the UI :( ... 