### PR TITLE
Always re-create external functions during UPGRADE_CHECK()

### DIFF
--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -40,6 +40,10 @@ returns varchar
 language sql
 as
 begin
+    -- Always call setup_external_functions to ensure the external_functions are re-created with the latest opscenter
+    -- token as Sundeck likely invalidated the previous token.
+    CALL admin.setup_external_functions('opscenter_api_integration');
+
     let version varchar;
     call internal.get_config('post_setup') into :version;
     let setup_version varchar := (select internal.get_version());


### PR DESCRIPTION
The linking to Sundeck path will set a new definition for internal.get_ef_token() but we don't want to proactively re-create the external functions because this takes a few seconds.

Instead, recreate the functions in UPGRADE_CHECK rather than in FINALIZE_SETUP which UPGRADE_CHECK may or may-not call.