### PR TITLE
Cleanup for latency's sake

### DIFF
--- a/app/ui/permissions.py
+++ b/app/ui/permissions.py
@@ -32,7 +32,7 @@ def setup_permissions():
 
     external_func_url = get_api_gateway_url(sf_region_without_public, sd_deployment)
     with connection.Connection.get() as conn:
-        conn.call("INTERNAL.SETUP_EF_URL", external_func_url)
+        conn.call("INTERNAL.SET_CONFIG", "url", external_func_url)
     privileges = [
         "EXECUTE MANAGED TASK",
         "EXECUTE TASK",

--- a/bootstrap/021_external_functions.sql
+++ b/bootstrap/021_external_functions.sql
@@ -320,12 +320,6 @@ $$
 $$;
 
 
-create function if not exists internal.get_tenant_url()
-    returns string
-    language javascript
-    as
-    'throw "You must configure a Sundeck token to use this.";';
-
 create function if not exists internal.get_ef_token()
     returns string
     language javascript

--- a/bootstrap/021_external_functions.sql
+++ b/bootstrap/021_external_functions.sql
@@ -513,3 +513,9 @@ BEGIN
     -- Success!
     return object_construct();
 END;
+
+-- remove deprecated functions if they still exist.
+drop function if exists internal.get_ef_url();
+drop function if exists internal.get_tenant_url();
+drop function if exists internal.setup_ef_url(string);
+drop function if exists internal.setup_sundeck_token(string, string);

--- a/bootstrap/021_external_functions.sql
+++ b/bootstrap/021_external_functions.sql
@@ -320,12 +320,6 @@ $$
 $$;
 
 
-create function if not exists internal.get_ef_url()
-    returns string
-    language javascript
-    as
-    'throw "You must configure a Sundeck token to use this.";';
-
 create function if not exists internal.get_tenant_url()
     returns string
     language javascript
@@ -338,17 +332,6 @@ create function if not exists internal.get_ef_token()
     as
     'throw "You must configure a Sundeck token to use this.";';
 
-create or replace procedure internal.setup_ef_url(url string) RETURNS STRING LANGUAGE SQL AS
-BEGIN
-    execute immediate 'create or replace function internal.get_ef_url() returns string as \'\\\'' || url || '\\\'\';';
-END;
-
-
-create or replace procedure internal.setup_sundeck_token(url string, token string) RETURNS STRING LANGUAGE SQL AS
-BEGIN
-    execute immediate 'create or replace function internal.get_ef_url() returns string as \'\\\'' || url || '\\\'\';';
-    execute immediate 'create or replace function internal.get_ef_token() returns string as \'\\\'' || token || '\\\'\';';
-END;
 
 BEGIN
     create function if not exists internal.ef_register_tenant(request object)
@@ -387,7 +370,7 @@ $$;
 
 CREATE OR REPLACE PROCEDURE admin.setup_register_tenant_func() RETURNS STRING LANGUAGE SQL AS
 BEGIN
-    let url string := (select internal.get_ef_url());
+    let url string := (select any_value(value) from internal.config where key = 'url');
     execute immediate '
         BEGIN
 	        create or replace external function internal.ef_register_tenant(request object)
@@ -415,7 +398,7 @@ BEGIN
     if (not :has_ref) then
         raise MISSING_REFERENCE;
     end if;
-    let url string := (select internal.get_ef_url());
+    let url string := (select any_value(value) from internal.config where key = 'url');
     let token string := (select internal.get_ef_token());
     execute immediate '
         BEGIN
@@ -523,6 +506,7 @@ begin
   return res;
 end;
 
+-- deprecated: to be deleted.
 create or replace procedure admin.connect_sundeck(token text)
     returns object
     language sql

--- a/bootstrap/039_reference_management.sql
+++ b/bootstrap/039_reference_management.sql
@@ -1,11 +1,6 @@
 
-create table if not exists internal.reference_management (
-    ref_name string,
-    operation string,
-    ref_or_alias string
-);
-
-create or replace view catalog.references as select * from internal.reference_management;
+drop view if exists catalog.references;
+drop table if exists internal.reference_management;
 
 create or replace procedure admin.update_reference(ref_name string, operation string, ref_or_alias string)
  returns string
@@ -15,13 +10,10 @@ begin
   case (operation)
     when 'ADD' then
        select system$set_reference(:ref_name, :ref_or_alias);
-       insert into internal.reference_management (ref_name, operation, ref_or_alias) values (:ref_name, 'Running external functions setup proc.', :ref_or_alias);
     when 'REMOVE' then
        select system$remove_reference(:ref_name, :ref_or_alias);
-       delete from internal.reference_management where name = :ref_name;
     when 'CLEAR' then
        select system$remove_all_references(:ref_name);
-       delete from internal.reference_management where name = :ref_name;
     else
        return 'Unknown operation: ' || operation;
   end case;

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -1,5 +1,5 @@
 
-create or replace procedure admin.finalize_setup(log_output boolean default true)
+create or replace procedure admin.finalize_setup()
 returns string
 language sql
 execute as owner
@@ -398,18 +398,12 @@ call internal.account_has_autoscaling() into :has_autoscaling;
 call internal.set_config('autoscaling_available', :has_autoscaling);
 CALL admin.setup_external_functions('opscenter_api_integration');
 
--- If a caller invokes this procedure directly, log the output. Else, the UPGRADE_CHECK task
--- is calling this procedure and handling logging.
-if (:log_output) then
-    INSERT INTO internal.upgrade_history SELECT :finalize_start_time, CURRENT_TIMESTAMP(), :old_version, internal.get_version(), 'Success';
-end if;
+INSERT INTO internal.upgrade_history SELECT :finalize_start_time, CURRENT_TIMESTAMP(), :old_version, internal.get_version(), 'FINALIZE_SETUP: Success';
 
 EXCEPTION
    WHEN OTHER THEN
-       if (:log_output) then
-           SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Unhandled exception occurred during finalize_setup.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
-           INSERT INTO internal.upgrade_history SELECT :finalize_start_time, CURRENT_TIMESTAMP(), :old_version, internal.get_version(), '(' || :sqlcode || ') state=' || :sqlstate || ' msg=' || :sqlerrm;
-       end if;
+       SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Unhandled exception occurred during finalize_setup.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
+       INSERT INTO internal.upgrade_history SELECT :finalize_start_time, CURRENT_TIMESTAMP(), :old_version, internal.get_version(), 'FINALIZE_SETUP: (' || :sqlcode || ') state=' || :sqlstate || ' msg=' || :sqlerrm;
        RAISE;
 END;
 

--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -51,15 +51,15 @@ declare
 begin
     call internal.get_config('post_setup') into :old_version;
     if (old_version is null or old_version <> setup_version) then
-        call admin.finalize_setup(false);
+        call admin.finalize_setup();
     end if;
 
-    INSERT INTO INTERNAL.UPGRADE_HISTORY SELECT :start_time, CURRENT_TIMESTAMP(), :old_version, :setup_version, 'Success';
+    INSERT INTO INTERNAL.UPGRADE_HISTORY SELECT :start_time, CURRENT_TIMESTAMP(), :old_version, :setup_version, 'UPGRADE_CHECK: Success';
 EXCEPTION
     WHEN OTHER THEN
         SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Unhandled exception occurred during UPGRADE_CHECK.', 'SQLCODE', :sqlcode,
             'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
         INSERT INTO INTERNAL.UPGRADE_HISTORY SELECT :start_time, CURRENT_TIMESTAMP(), :old_version, setup_version,
-            '(' || :sqlcode || ') state=' || :sqlstate || ' msg=' || :sqlerrm;
+            'UPGRADE_CHECK: (' || :sqlcode || ') state=' || :sqlstate || ' msg=' || :sqlerrm;
         RAISE;
 end;

--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -18,9 +18,8 @@ begin
     -- Merge all three properties into the config table in one merge statement.
     MERGE INTO internal.config AS target
     USING (
-        SELECT $1 as key, $2 as value from VALUES(
+        SELECT $1 as key, $2 as value from VALUES
             ('tenant_url', :web_url), ('url', :url), ('tenant_id', split_part(:web_url, '/', -1))
-        )
     ) AS source
     ON target.key = source.key
     WHEN MATCHED THEN

--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -5,7 +5,6 @@ RETURNS object
 LANGUAGE sql
 as
 begin
-    execute immediate 'create or replace function internal.get_ef_url() returns string as \'\\\'' || url || '\\\'\';';
     execute immediate 'create or replace function internal.get_tenant_url() returns string as \'\\\'' || web_url || '\\\'\';';
 
     -- Create the task so we can run finalize_setup asynchronously (duplicated in finalize_setup)
@@ -30,7 +29,8 @@ begin
     -- Save the token if provided
     let ret object;
     if (token is not null) then
-        call admin.connect_sundeck(:token) into :ret;
+        -- Create the scalar UDF for the Sundeck auth token (EF URL set up by the app in permissions.py)
+        execute immediate 'create or replace function internal.get_ef_token() returns string as \'\\\'' || token || '\\\'\';';
         CALL admin.setup_external_functions('opscenter_api_integration');
     end if;
     return :ret;

--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -5,8 +5,6 @@ RETURNS object
 LANGUAGE sql
 as
 begin
-    execute immediate 'create or replace function internal.get_tenant_url() returns string as \'\\\'' || web_url || '\\\'\';';
-
     -- Create the task so we can run finalize_setup asynchronously (duplicated in finalize_setup)
     -- Does not start the task -- the first time the task runs, finalize_setup() will start the task.
     CREATE OR REPLACE TASK TASKS.UPGRADE_CHECK


### PR DESCRIPTION
* Remove internal.get_ef_url() and use the row from the internal.config table
* Remove unused internal.get_tenant_url UDF
* Replace the 3x `internal.set_config()` calls in `admin.finalize_setup_with_service_account() with a single `merge`
* Remove the `internal.reference_management` table as we do nothing with it.
* Create the normal task log table and view for `UPGRADE_CHECK`

This PR intentionally does not move code around for additional parallelism as we discussed. That will come in a second PR after verifying these changes work as expected.

Will be doing some manual poking and prodding on this PR, too.