### PR TITLE
New procedures which break apart finalize_setup_from_service_account()

### DIFF
--- a/bootstrap/039_reference_management.sql
+++ b/bootstrap/039_reference_management.sql
@@ -3,8 +3,8 @@ drop view if exists catalog.references;
 drop table if exists internal.reference_management;
 
 create or replace procedure admin.update_reference(ref_name string, operation string, ref_or_alias string)
- language sql
  returns string
+ language sql
  as
 begin
   SYSTEM$LOG_INFO('Updating reference: ' || ref_name || ' operation: ' || operation || ' ref_or_alias: ' || ref_or_alias);

--- a/bootstrap/039_reference_management.sql
+++ b/bootstrap/039_reference_management.sql
@@ -3,8 +3,9 @@ drop view if exists catalog.references;
 drop table if exists internal.reference_management;
 
 create or replace procedure admin.update_reference(ref_name string, operation string, ref_or_alias string)
+ language sql
  returns string
- as $$
+ as
 begin
   SYSTEM$LOG_INFO('Updating reference: ' || ref_name || ' operation: ' || operation || ' ref_or_alias: ' || ref_or_alias);
   case (operation)
@@ -17,6 +18,5 @@ begin
     else
        return 'Unknown operation: ' || operation;
   end case;
-  return 'Success';
+  return '';
 end;
-$$;

--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -67,7 +67,7 @@ BEGIN
     MERGE INTO internal.config AS target
     USING (
         SELECT $1 as key, $2 as value from VALUES
-            ('tenant_url', :web_url), ('url', :url), ('tenant_id', tenant_id)
+            ('tenant_url', :web_url), ('url', :url), ('tenant_id', :tenant_id)
     ) AS source
     ON target.key = source.key
     WHEN MATCHED THEN

--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -58,7 +58,7 @@ BEGIN
 END;
 
 -- Merges tenant_url, url, and tenant_id into the config table. Conditionally updates the internal.get_ef_token UDF.
-CREATE OR REPLACE PROCEDURE admin.update_sundeck_configuration(url varchar, web_url varchar, token varchar default null)
+CREATE OR REPLACE PROCEDURE admin.update_sundeck_configuration(url varchar, web_url varchar, tenant_id varchar, token varchar default null)
 RETURNS TEXT
 LANGUAGE SQL
 AS
@@ -67,7 +67,7 @@ BEGIN
     MERGE INTO internal.config AS target
     USING (
         SELECT $1 as key, $2 as value from VALUES
-            ('tenant_url', :web_url), ('url', :url), ('tenant_id', split_part(:web_url, '/', -1))
+            ('tenant_url', :web_url), ('url', :url), ('tenant_id', tenant_id)
     ) AS source
     ON target.key = source.key
     WHEN MATCHED THEN


### PR DESCRIPTION
We must always call setup_external_functions in upgrade_check.

The three pieces we can now call concurrently (in place of `finalize_setup_with_service_account()`) are:
* `admin.update_reference(text, text, text)`
* `admin.create_upgrade_check()`
* `admin.update_sundeck_configuration(text, text, text)`