### PR TITLE
Create a singular INTERNAL.TASK_LOG table which records query_id

### DIFF
--- a/app/ui/Home.py
+++ b/app/ui/Home.py
@@ -84,8 +84,8 @@ def get_refresh_data():
     query_end_times = (
         "select value from catalog.config where key  = 'QUERY_HISTORY_MAINTENANCE'"
     )
-    queryh_start_times = "select max(run) from internal.task_query_history"
-    warehouse_start_times = "select max(run) from internal.task_warehouse_events"
+    queryh_start_times = "select max(task_start) from internal.task_log where success AND object_type = 'QUERY_HISTORY' AND object_name = 'QUERY_HISTORY'"
+    warehouse_start_times = "select max(task_start) from internal.task_log where success AND object_type = 'WAREHOUSE_EVENTS' AND object_name = 'WAREHOUSE_EVENTS_HISTORY'"
     range_min = "select min(start_time) from reporting.enriched_query_history"
     range_max = "select max(start_time) from reporting.enriched_query_history"
     qet = get(

--- a/app/ui/Home.py
+++ b/app/ui/Home.py
@@ -84,8 +84,8 @@ def get_refresh_data():
     query_end_times = (
         "select value from catalog.config where key  = 'QUERY_HISTORY_MAINTENANCE'"
     )
-    queryh_start_times = "select max(task_start) from internal.task_log where success AND object_type = 'QUERY_HISTORY' AND object_name = 'QUERY_HISTORY'"
-    warehouse_start_times = "select max(task_start) from internal.task_log where success AND object_type = 'WAREHOUSE_EVENTS' AND object_name = 'WAREHOUSE_EVENTS_HISTORY'"
+    queryh_start_times = "select max(task_start) from internal.task_log where success AND task_name = 'QUERY_HISTORY_MAINTENANCE' AND object_name = 'QUERY_HISTORY'"
+    warehouse_start_times = "select max(task_start) from internal.task_log where success AND task_name = 'WAREHOUSE_EVENTS_MAINTENANCE' AND object_name = 'WAREHOUSE_EVENTS_HISTORY'"
     range_min = "select min(start_time) from reporting.enriched_query_history"
     range_max = "select max(start_time) from reporting.enriched_query_history"
     qet = get(

--- a/app/ui/pages/10_Settings.py
+++ b/app/ui/pages/10_Settings.py
@@ -279,8 +279,7 @@ with reset:
         connection.execute(
             """
         begin
-            truncate table internal.task_query_history;
-            truncate table internal.task_warehouse_events;
+            truncate table internal.task_log;
             truncate table internal_reporting_mv.cluster_and_warehouse_sessions_complete_and_daily;
             truncate table internal_reporting_mv.query_history_complete_and_daily;
         end;

--- a/bootstrap/012_task_log.sql
+++ b/bootstrap/012_task_log.sql
@@ -14,18 +14,18 @@ $$
 $$;
 
 -- Inserts a row into TASK_LOG with the time the task started, the name of the object being materialized, the graph run ID and query_id for the task.
-create or replace procedure internal.start_task(task_name text, object_name text, start_time timestamp_ltz, task_run_id text, query_id text)
+create or replace procedure internal.start_task(task_name text, object_name text, start_time text, task_run_id text, query_id text)
     returns object
     language sql
 AS
 BEGIN
     let input object := (select output from INTERNAL.TASK_LOG where success AND task_name = :task_name AND object_name = :object_name order by task_start desc limit 1);
-    INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, task_name, object_name) select :start_time, :task_run_id, :query_id, :input, :task_name, :object_name;
+    INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, task_name, object_name) select :start_time::TIMESTAMP_LTZ, :task_run_id, :query_id, :input, :task_name, :object_name;
     return input;
 END;
 
 -- Updates the row created by START_TASK with the time the task finish, the success and output object of the task, and the min/max date range of the data that is now materialized.
-create or replace procedure internal.finish_task(task_name text, object_name text, start_time timestamp_ltz, task_run_id text, output object)
+create or replace procedure internal.finish_task(task_name text, object_name text, start_time text, task_run_id text, output object)
     returns text
     language sql
 AS
@@ -35,12 +35,12 @@ BEGIN
     let range_max timestamp_ltz := (select :output['range_max']);
     UPDATE INTERNAL.TASK_LOG
         SET success = :success, output = :output, task_finish = current_timestamp(), range_min = :range_min, range_max = :range_max
-        WHERE task_start = :start_time AND task_run_id = :task_run_id AND task_name = :task_name AND object_name = :object_name;
+        WHERE task_start = :start_time::TIMESTAMP_LTZ AND task_run_id = :task_run_id AND task_name = :task_name AND object_name = :object_name;
 END;
 
 -- Special case for the warehouse events task, which inserts extra rows into task log breaking out warehouse and cluster sessions details to
 -- ease reporting on each dataset.
-create or replace procedure internal.finish_warehouse_events_task(task_name text, start_time timestamp_ltz, task_run_id text, query_id text, input object, output object)
+create or replace procedure internal.finish_warehouse_events_task(task_name text, start_time text, task_run_id text, query_id text, input object, output object)
     returns text
     language sql
 AS
@@ -49,12 +49,12 @@ BEGIN
     let cluster_range_min timestamp_ltz := (select :output['cluster_range_min']);
     let cluster_range_max timestamp_ltz := (select :output['cluster_range_max']);
     INSERT INTO INTERNAL.TASK_LOG(task_start, success, task_name, object_name, input, output, task_finish, task_run_id, query_id, range_min, range_max)
-    select :start_time, :success, :task_name, 'CLUSTER_SESSIONS', :input, :output, current_timestamp(), :task_run_id, :query_id, :cluster_range_min, :cluster_range_max;
+    select :start_time::TIMESTAMP_LTZ, :success, :task_name, 'CLUSTER_SESSIONS', :input, :output, current_timestamp(), :task_run_id, :query_id, :cluster_range_min, :cluster_range_max;
 
     let warehouse_range_min timestamp_ltz := (select :output['warehouse_range_min']);
     let warehouse_range_max timestamp_ltz := (select :output['warehouse_range_max']);
     INSERT INTO INTERNAL.TASK_LOG(task_start, success, task_name, object_name, input, output, task_finish, task_run_id, query_id, range_min, range_max)
-    select :start_time, :success, :task_name, 'WAREHOUSE_SESSIONS', :input, :output, current_timestamp(), :task_run_id, :query_id, :warehouse_range_min, :warehouse_range_max;
+    select :start_time::TIMESTAMP_LTZ, :success, :task_name, 'WAREHOUSE_SESSIONS', :input, :output, current_timestamp(), :task_run_id, :query_id, :warehouse_range_min, :warehouse_range_max;
 END;
 
 -- Generic table that tasks should record their execution into.

--- a/bootstrap/012_task_log.sql
+++ b/bootstrap/012_task_log.sql
@@ -6,8 +6,6 @@ $$
      SYSTEM$TASK_RUNTIME_INFO('CURRENT_TASK_GRAPH_RUN_GROUP_ID')
 $$;
 
-let task_log_exists boolean := (exists (select * from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_LOG'));
-
 -- Generic table that tasks should record their execution into.
 CREATE TABLE INTERNAL.TASK_LOG IF NOT EXISTS (task_start timestamp_ltz, success boolean, task_name varchar, object_name varchar,
     input variant, output variant, task_finish timestamp_ltz, task_run_id text, query_id text);
@@ -22,25 +20,26 @@ BEGIN
         INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
             SELECT tqh.run, tqh.success, 'QUERY_HISTORY_MAINTENANCE', 'QUERY_HISTORY', tqh.input, tqh.output, null
             FROM INTERNAL.TASK_QUERY_HISTORY tqh;
+        TRUNCATE TABLE INTERNAL.TASK_QUERY_HISTORY;
     end if;
 
     if (exists (select * from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_WAREHOUSE_EVENTS')) then
         INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
             SELECT twe.run, twe.success, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY', twe.input, twe.output, null
             FROM INTERNAL.TASK_WAREHOUSE_EVENTS twe;
+        TRUNCATE TABLE INTERNAL.TASK_WAREHOUSE_EVENTS;
     end if;
 
-    if (exists (select 1 from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_SIMPLE_DATA_EVENTS')) then
+    if (exists (select * from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_SIMPLE_DATA_EVENTS')) then
         INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
             SELECT tsde.run, tsde.success, 'SIMPLE_DATA_EVENTS_MAINTENANCE', tsde.table_name, tsde.input, tsde.output, null
             FROM INTERNAL.TASK_SIMPLE_DATA_EVENTS tsde;
+        TRUNCATE TABLE INTERNAL.TASK_SIMPLE_DATA_EVENTS;
     end if;
 END;
 
--- If the task_log table didn't exist, try to migrate any previous materialization records
-IF (NOT task_log_exists) THEN
-    call internal.migrate_task_logs();
-END IF;
+-- Try to migrate any previous task log records from the old tables
+call internal.migrate_task_logs();
 
 -- Create specific-purpose views that we had before.
 CREATE OR REPLACE VIEW REPORTING.SIMPLE_DATA_EVENTS_TASK_HISTORY AS SELECT * exclude (task_name) rename (object_name as table_name)

--- a/bootstrap/012_task_log.sql
+++ b/bootstrap/012_task_log.sql
@@ -14,7 +14,7 @@ $$
 $$;
 
 -- Inserts a row into TASK_LOG with the time the task started, the name of the object being materialized, the graph run ID and query_id for the task.
-create or replace procedure internal.start_task(task_name text, object_name text, start_time text, task_run_id text, query_id text)
+create or replace procedure internal.start_task(task_name text, object_name text, start_time timestamp_ntz, task_run_id text, query_id text)
     returns object
     language sql
 AS
@@ -25,7 +25,7 @@ BEGIN
 END;
 
 -- Updates the row created by START_TASK with the time the task finish, the success and output object of the task, and the min/max date range of the data that is now materialized.
-create or replace procedure internal.finish_task(task_name text, object_name text, start_time text, task_run_id text, output object)
+create or replace procedure internal.finish_task(task_name text, object_name text, start_time timestamp_ntz, task_run_id text, output object)
     returns text
     language sql
 AS
@@ -40,7 +40,7 @@ END;
 
 -- Special case for the warehouse events task, which inserts extra rows into task log breaking out warehouse and cluster sessions details to
 -- ease reporting on each dataset.
-create or replace procedure internal.finish_warehouse_events_task(task_name text, start_time text, task_run_id text, query_id text, input object, output object)
+create or replace procedure internal.finish_warehouse_events_task(task_name text, start_time timestamp_ntz, task_run_id text, query_id text, input object, output object)
     returns text
     language sql
 AS
@@ -49,17 +49,17 @@ BEGIN
     let cluster_range_min timestamp_ltz := (select :output['cluster_range_min']);
     let cluster_range_max timestamp_ltz := (select :output['cluster_range_max']);
     INSERT INTO INTERNAL.TASK_LOG(task_start, success, task_name, object_name, input, output, task_finish, task_run_id, query_id, range_min, range_max)
-    select :start_time::TIMESTAMP_LTZ, :success, :task_name, 'CLUSTER_SESSIONS', :input, :output, current_timestamp(), :task_run_id, :query_id, :cluster_range_min, :cluster_range_max;
+    select :start_time, :success, :task_name, 'CLUSTER_SESSIONS', :input, :output, current_timestamp(), :task_run_id, :query_id, :cluster_range_min, :cluster_range_max;
 
     let warehouse_range_min timestamp_ltz := (select :output['warehouse_range_min']);
     let warehouse_range_max timestamp_ltz := (select :output['warehouse_range_max']);
     INSERT INTO INTERNAL.TASK_LOG(task_start, success, task_name, object_name, input, output, task_finish, task_run_id, query_id, range_min, range_max)
-    select :start_time::TIMESTAMP_LTZ, :success, :task_name, 'WAREHOUSE_SESSIONS', :input, :output, current_timestamp(), :task_run_id, :query_id, :warehouse_range_min, :warehouse_range_max;
+    select :start_time, :success, :task_name, 'WAREHOUSE_SESSIONS', :input, :output, current_timestamp(), :task_run_id, :query_id, :warehouse_range_min, :warehouse_range_max;
 END;
 
 -- Generic table that tasks should record their execution into.
-CREATE TABLE INTERNAL.TASK_LOG IF NOT EXISTS (task_start timestamp_ltz, success boolean, task_name varchar, object_name varchar,
-    input variant, output variant, task_finish timestamp_ltz, task_run_id text, query_id text, range_min timestamp_ltz, range_max timestamp_ltz);
+CREATE TABLE INTERNAL.TASK_LOG IF NOT EXISTS (task_start timestamp_ntz, success boolean, task_name varchar, object_name varchar,
+    input variant, output variant, task_finish timestamp_ntz, task_run_id text, query_id text, range_min timestamp_ltz, range_max timestamp_ltz);
 
 -- migrate the old, separate "task log" tables into the consolidated task_log table.
 create or replace procedure internal.migrate_task_logs()

--- a/bootstrap/012_task_log.sql
+++ b/bootstrap/012_task_log.sql
@@ -6,43 +6,49 @@ $$
      SYSTEM$TASK_RUNTIME_INFO('CURRENT_TASK_GRAPH_RUN_GROUP_ID')
 $$;
 
-let task_log_exists boolean := false;
-if exists (select 1 from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_LOG') then
-    task_log_exists := true;
-end if;
+let task_log_exists boolean := (exists (select * from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_LOG'));
 
 -- Generic table that tasks should record their execution into.
-CREATE TABLE INTERNAL.TASK_LOG IF NOT EXISTS (task_start timestamp_ltz, success boolean, object_type varchar, object_name varchar,
+CREATE TABLE INTERNAL.TASK_LOG IF NOT EXISTS (task_start timestamp_ltz, success boolean, task_name varchar, object_name varchar,
     input variant, output variant, task_finish timestamp_ltz, task_run_id text, query_id text);
 
--- If the task_log table didn't exist, try to migrate any previous materialization records
-IF (NOT task_log_exists) THEN
-    if exists (select 1 from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_QUERY_HISTORY') then
-        INSERT INTO INTERNAL.TASK_LOG (task_start, success, object_type, object_name, input, output, task_finish)
-            SELECT tqh.run, tqh.success, 'QUERY_HISTORY', 'QUERY_HISTORY', tqh.input, tqh.output, null
+create or replace procedure internal.migrate_task_logs()
+    returns text
+    language sql
+AS
+BEGIN
+    -- If the old task log tables exist, copy the rows into the new task_log table
+    if (exists (select * from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_QUERY_HISTORY')) then
+        INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
+            SELECT tqh.run, tqh.success, 'QUERY_HISTORY_MAINTENANCE', 'QUERY_HISTORY', tqh.input, tqh.output, null
             FROM INTERNAL.TASK_QUERY_HISTORY tqh;
     end if;
 
-    if exists (select 1 from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_WAREHOUSE_EVENTS') then
-        INSERT INTO INTERNAL.TASK_LOG (task_start, success, object_type, object_name, input, output, task_finish)
-            SELECT twe.run, twe.success, 'WAREHOUSE_EVENTS', 'WAREHOUSE_EVENTS_HISTORY', twe.input, twe.output, null
+    if (exists (select * from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_WAREHOUSE_EVENTS')) then
+        INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
+            SELECT twe.run, twe.success, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY', twe.input, twe.output, null
             FROM INTERNAL.TASK_WAREHOUSE_EVENTS twe;
     end if;
 
-    if exists (select 1 from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_SIMPLE_DATA_EVENTS') then
-        INSERT INTO INTERNAL.TASK_LOG (task_start, success, object_type, object_name, input, output, task_finish)
-            SELECT tsde.run, tsde.success, 'SIMPLE_DATA_EVENT', tsde.table_name, tsde.input, tsde.output, null
+    if (exists (select 1 from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_SIMPLE_DATA_EVENTS')) then
+        INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
+            SELECT tsde.run, tsde.success, 'SIMPLE_DATA_EVENTS_MAINTENANCE', tsde.table_name, tsde.input, tsde.output, null
             FROM INTERNAL.TASK_SIMPLE_DATA_EVENTS tsde;
     end if;
+END;
+
+-- If the task_log table didn't exist, try to migrate any previous materialization records
+IF (NOT task_log_exists) THEN
+    call internal.migrate_task_logs();
 END IF;
 
 -- Create specific-purpose views that we had before.
-CREATE OR REPLACE VIEW REPORTING.SIMPLE_DATA_EVENTS_TASK_HISTORY AS SELECT * exclude (object_name) rename (object_type as table_name)
-    FROM INTERNAL.TASK_LOG WHERE object_type = 'SIMPLE_DATA_EVENT';
-CREATE OR REPLACE VIEW REPORTING.WAREHOUSE_LOAD_EVENTS_TASK_HISTORY AS SELECT * exclude (object_name) rename (object_type as warehouse_name)
-    FROM INTERNAL.TASK_LOG where object_type = 'WAREHOUSE_LOAD_EVENT';
+CREATE OR REPLACE VIEW REPORTING.SIMPLE_DATA_EVENTS_TASK_HISTORY AS SELECT * exclude (task_name) rename (object_name as table_name)
+    FROM INTERNAL.TASK_LOG WHERE task_name = 'SIMPLE_DATA_EVENTS_MAINTENANCE';
+CREATE OR REPLACE VIEW REPORTING.WAREHOUSE_LOAD_EVENTS_TASK_HISTORY AS SELECT * exclude (task_name) rename (object_name as warehouse_name)
+    FROM INTERNAL.TASK_LOG where task_name = 'WAREHOUSE_LOAD_MAINTENANCE';
 CREATE OR REPLACE VIEW REPORTING.UPGRADE_HISTORY AS SELECT task_start, success, output['old_version'] as old_version, output['new_version'] as new_version, task_finish, task_run_id, query_id,
-    FROM INTERNAL.TASK_LOG where object_type = 'UPGRADE';
+    FROM INTERNAL.TASK_LOG where task_name = 'UPGRADE_CHECK';
 
 -- Create a generic view for all task executions.
 CREATE OR REPLACE VIEW REPORTING.TASK_LOG_HISTORY AS SELECT * FROM INTERNAL.TASK_LOG;

--- a/bootstrap/012_task_log.sql
+++ b/bootstrap/012_task_log.sql
@@ -1,10 +1,36 @@
 
+create or replace function internal.root_task_id()
+returns text
+AS
+$$
+     SYSTEM$TASK_RUNTIME_INFO('CURRENT_ROOT_TASK_UUID')
+$$;
+
 create or replace function internal.task_run_id()
 returns text
 AS
 $$
      SYSTEM$TASK_RUNTIME_INFO('CURRENT_TASK_GRAPH_RUN_GROUP_ID')
 $$;
+
+create or replace procedure internal.start_task(task_name text, object_name text, start_time timestamp_ltz, task_run_id text, query_id text)
+    returns object
+    language sql
+AS
+BEGIN
+    let input variant := (select output from INTERNAL.TASK_LOG where success AND task_name = :task_name AND object_name = :object_name order by task_start desc limit 1);
+    INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, task_name, object_name) select :start_time, :task_run_id, :query_id, :input, :task_name, :object_name;
+    return input;
+END;
+
+create or replace procedure internal.finish_task(task_name text, object_name text, start_time timestamp_ltz, task_run_id text, output object)
+    returns text
+    language sql
+AS
+BEGIN
+    let success boolean := (select :output['SQLERRM'] is null);
+    UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id AND task_name = :task_name AND object_name = :object_name;
+END;
 
 -- Generic table that tasks should record their execution into.
 CREATE TABLE INTERNAL.TASK_LOG IF NOT EXISTS (task_start timestamp_ltz, success boolean, task_name varchar, object_name varchar,
@@ -17,24 +43,46 @@ AS
 BEGIN
     -- If the old task log tables exist, copy the rows into the new task_log table
     if (exists (select * from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_QUERY_HISTORY')) then
-        INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
-            SELECT tqh.run, tqh.success, 'QUERY_HISTORY_MAINTENANCE', 'QUERY_HISTORY', tqh.input, tqh.output, null
-            FROM INTERNAL.TASK_QUERY_HISTORY tqh;
-        DROP TABLE INTERNAL.TASK_QUERY_HISTORY;
+        BEGIN TRANSACTION;
+        let config_key := (select 'MIGRATION_TASK_QUERY_HISTORY');
+        let config_value text;
+        call internal.get_config(config_key) into :config_value;
+        if (config_value is null) then
+            INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
+                SELECT tqh.run, tqh.success, 'QUERY_HISTORY_MAINTENANCE', 'QUERY_HISTORY', tqh.input, tqh.output, null
+                FROM INTERNAL.TASK_QUERY_HISTORY tqh;
+            call internal.set_config(config_key, 'true');
+        END IF;
+        commit;
     end if;
 
     if (exists (select * from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_WAREHOUSE_EVENTS')) then
-        INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
-            SELECT twe.run, twe.success, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY', twe.input, twe.output, null
-            FROM INTERNAL.TASK_WAREHOUSE_EVENTS twe;
-        DROP TABLE INTERNAL.TASK_WAREHOUSE_EVENTS;
+        BEGIN TRANSACTION;
+        let config_key := (select 'MIGRATION_TASK_WAREHOUSE_EVENTS');
+        let config_value text;
+        call internal.get_config(config_key) into :config_value;
+        if (config_value is null) then
+            INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
+                SELECT twe.run, twe.success, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY', twe.input, twe.output, null
+                FROM INTERNAL.TASK_WAREHOUSE_EVENTS twe;
+            call internal.set_config(config_key, 'true');
+        END IF;
+        commit;
     end if;
 
     if (exists (select * from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_SIMPLE_DATA_EVENTS')) then
-        INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
-            SELECT tsde.run, tsde.success, 'SIMPLE_DATA_EVENTS_MAINTENANCE', tsde.table_name, tsde.input, tsde.output, null
-            FROM INTERNAL.TASK_SIMPLE_DATA_EVENTS tsde;
-        DROP TABLE INTERNAL.TASK_SIMPLE_DATA_EVENTS;
+        BEGIN TRANSACTION;
+        let config_key := (select 'MIGRATION_TASK_SIMPLE_DATA_EVENTS');
+        let config_value text;
+        call internal.get_config(config_key) into :config_value;
+        if (config_value is null) then
+            -- Different from the previous, carrying table_name into task_log as object_name
+            INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
+                SELECT tsde.run, tsde.success, 'SIMPLE_DATA_EVENTS_MAINTENANCE', tsde.table_name, tsde.input, tsde.output, null
+                FROM INTERNAL.TASK_SIMPLE_DATA_EVENTS tsde;
+            call internal.set_config(config_key, 'true');
+        END IF;
+        commit;
     end if;
 END;
 

--- a/bootstrap/012_task_log.sql
+++ b/bootstrap/012_task_log.sql
@@ -20,21 +20,21 @@ BEGIN
         INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
             SELECT tqh.run, tqh.success, 'QUERY_HISTORY_MAINTENANCE', 'QUERY_HISTORY', tqh.input, tqh.output, null
             FROM INTERNAL.TASK_QUERY_HISTORY tqh;
-        TRUNCATE TABLE INTERNAL.TASK_QUERY_HISTORY;
+        DROP TABLE INTERNAL.TASK_QUERY_HISTORY;
     end if;
 
     if (exists (select * from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_WAREHOUSE_EVENTS')) then
         INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
             SELECT twe.run, twe.success, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY', twe.input, twe.output, null
             FROM INTERNAL.TASK_WAREHOUSE_EVENTS twe;
-        TRUNCATE TABLE INTERNAL.TASK_WAREHOUSE_EVENTS;
+        DROP TABLE INTERNAL.TASK_WAREHOUSE_EVENTS;
     end if;
 
     if (exists (select * from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_SIMPLE_DATA_EVENTS')) then
         INSERT INTO INTERNAL.TASK_LOG (task_start, success, task_name, object_name, input, output, task_finish)
             SELECT tsde.run, tsde.success, 'SIMPLE_DATA_EVENTS_MAINTENANCE', tsde.table_name, tsde.input, tsde.output, null
             FROM INTERNAL.TASK_SIMPLE_DATA_EVENTS tsde;
-        TRUNCATE TABLE INTERNAL.TASK_SIMPLE_DATA_EVENTS;
+        DROP TABLE INTERNAL.TASK_SIMPLE_DATA_EVENTS;
     end if;
 END;
 

--- a/bootstrap/012_task_log.sql
+++ b/bootstrap/012_task_log.sql
@@ -13,29 +13,36 @@ $$
      SYSTEM$TASK_RUNTIME_INFO('CURRENT_TASK_GRAPH_RUN_GROUP_ID')
 $$;
 
+-- Inserts a row into TASK_LOG with the time the task started, the name of the object being materialized, the graph run ID and query_id for the task.
 create or replace procedure internal.start_task(task_name text, object_name text, start_time timestamp_ltz, task_run_id text, query_id text)
     returns object
     language sql
 AS
 BEGIN
-    let input variant := (select output from INTERNAL.TASK_LOG where success AND task_name = :task_name AND object_name = :object_name order by task_start desc limit 1);
+    let input object := (select output from INTERNAL.TASK_LOG where success AND task_name = :task_name AND object_name = :object_name order by task_start desc limit 1);
     INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, task_name, object_name) select :start_time, :task_run_id, :query_id, :input, :task_name, :object_name;
     return input;
 END;
 
+-- Updates the row created by START_TASK with the time the task finish, the success and output object of the task, and the min/max date range of the data that is now materialized.
 create or replace procedure internal.finish_task(task_name text, object_name text, start_time timestamp_ltz, task_run_id text, output object)
     returns text
     language sql
 AS
 BEGIN
     let success boolean := (select :output['SQLERRM'] is null);
-    UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id AND task_name = :task_name AND object_name = :object_name;
+    let range_min timestamp_ltz := (select :output['range_min']);
+    let range_max timestamp_ltz := (select :output['range_max']);
+    UPDATE INTERNAL.TASK_LOG
+        SET success = :success, output = :output, task_finish = current_timestamp(), range_min = :range_min, range_max = :range_max
+        WHERE task_start = :start_time AND task_run_id = :task_run_id AND task_name = :task_name AND object_name = :object_name;
 END;
 
 -- Generic table that tasks should record their execution into.
 CREATE TABLE INTERNAL.TASK_LOG IF NOT EXISTS (task_start timestamp_ltz, success boolean, task_name varchar, object_name varchar,
-    input variant, output variant, task_finish timestamp_ltz, task_run_id text, query_id text);
+    input variant, output variant, task_finish timestamp_ltz, task_run_id text, query_id text, range_min timestamp_ltz, range_max timestamp_ltz);
 
+-- migrate the old, separate "task log" tables into the consolidated task_log table.
 create or replace procedure internal.migrate_task_logs()
     returns text
     language sql

--- a/bootstrap/012_task_log.sql
+++ b/bootstrap/012_task_log.sql
@@ -1,0 +1,48 @@
+
+create or replace function internal.task_run_id()
+returns text
+AS
+$$
+     SYSTEM$TASK_RUNTIME_INFO('CURRENT_TASK_GRAPH_RUN_GROUP_ID')
+$$;
+
+let task_log_exists boolean := false;
+if exists (select 1 from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_LOG') then
+    task_log_exists := true;
+end if;
+
+-- Generic table that tasks should record their execution into.
+CREATE TABLE INTERNAL.TASK_LOG IF NOT EXISTS (task_start timestamp_ltz, success boolean, object_type varchar, object_name varchar,
+    input variant, output variant, task_finish timestamp_ltz, task_run_id text, query_id text);
+
+-- If the task_log table didn't exist, try to migrate any previous materialization records
+IF (NOT task_log_exists) THEN
+    if exists (select 1 from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_QUERY_HISTORY') then
+        INSERT INTO INTERNAL.TASK_LOG (task_start, success, object_type, object_name, input, output, task_finish)
+            SELECT tqh.run, tqh.success, 'QUERY_HISTORY', 'QUERY_HISTORY', tqh.input, tqh.output, null
+            FROM INTERNAL.TASK_QUERY_HISTORY tqh;
+    end if;
+
+    if exists (select 1 from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_WAREHOUSE_EVENTS') then
+        INSERT INTO INTERNAL.TASK_LOG (task_start, success, object_type, object_name, input, output, task_finish)
+            SELECT twe.run, twe.success, 'WAREHOUSE_EVENTS', 'WAREHOUSE_EVENTS_HISTORY', twe.input, twe.output, null
+            FROM INTERNAL.TASK_WAREHOUSE_EVENTS twe;
+    end if;
+
+    if exists (select 1 from information_schema.tables where table_schema = 'INTERNAL' and table_name = 'TASK_SIMPLE_DATA_EVENTS') then
+        INSERT INTO INTERNAL.TASK_LOG (task_start, success, object_type, object_name, input, output, task_finish)
+            SELECT tsde.run, tsde.success, 'SIMPLE_DATA_EVENT', tsde.table_name, tsde.input, tsde.output, null
+            FROM INTERNAL.TASK_SIMPLE_DATA_EVENTS tsde;
+    end if;
+END IF;
+
+-- Create specific-purpose views that we had before.
+CREATE OR REPLACE VIEW REPORTING.SIMPLE_DATA_EVENTS_TASK_HISTORY AS SELECT * exclude (object_name) rename (object_type as table_name)
+    FROM INTERNAL.TASK_LOG WHERE object_type = 'SIMPLE_DATA_EVENT';
+CREATE OR REPLACE VIEW REPORTING.WAREHOUSE_LOAD_EVENTS_TASK_HISTORY AS SELECT * exclude (object_name) rename (object_type as warehouse_name)
+    FROM INTERNAL.TASK_LOG where object_type = 'WAREHOUSE_LOAD_EVENT';
+CREATE OR REPLACE VIEW REPORTING.UPGRADE_HISTORY AS SELECT task_start, success, output['old_version'] as old_version, output['new_version'] as new_version, task_finish, task_run_id, query_id,
+    FROM INTERNAL.TASK_LOG where object_type = 'UPGRADE';
+
+-- Create a generic view for all task executions.
+CREATE OR REPLACE VIEW REPORTING.TASK_LOG_HISTORY AS SELECT * FROM INTERNAL.TASK_LOG;

--- a/bootstrap/012_task_log.sql
+++ b/bootstrap/012_task_log.sql
@@ -96,13 +96,5 @@ END;
 -- Try to migrate any previous task log records from the old tables
 call internal.migrate_task_logs();
 
--- Create specific-purpose views that we had before.
-CREATE OR REPLACE VIEW REPORTING.SIMPLE_DATA_EVENTS_TASK_HISTORY AS SELECT * exclude (task_name) rename (object_name as table_name)
-    FROM INTERNAL.TASK_LOG WHERE task_name = 'SIMPLE_DATA_EVENTS_MAINTENANCE';
-CREATE OR REPLACE VIEW REPORTING.WAREHOUSE_LOAD_EVENTS_TASK_HISTORY AS SELECT * exclude (task_name) rename (object_name as warehouse_name)
-    FROM INTERNAL.TASK_LOG where task_name = 'WAREHOUSE_LOAD_MAINTENANCE';
-CREATE OR REPLACE VIEW REPORTING.UPGRADE_HISTORY AS SELECT task_start, success, output['old_version'] as old_version, output['new_version'] as new_version, task_finish, task_run_id, query_id,
-    FROM INTERNAL.TASK_LOG where task_name = 'UPGRADE_CHECK';
-
 -- Create a generic view for all task executions.
 CREATE OR REPLACE VIEW REPORTING.TASK_LOG_HISTORY AS SELECT * FROM INTERNAL.TASK_LOG;

--- a/bootstrap/018_warehouse_updates.sql
+++ b/bootstrap/018_warehouse_updates.sql
@@ -33,7 +33,7 @@ begin
     return object_construct('migrate1', migrate1, 'migrate2', migrate2);
 end;
 
-CREATE OR REPLACE PROCEDURE internal.refresh_warehouse_events(migrate boolean, input variant) RETURNS VARIANT LANGUAGE SQL
+CREATE OR REPLACE PROCEDURE internal.refresh_warehouse_events(migrate boolean, input variant) RETURNS OBJECT LANGUAGE SQL
     COMMENT = 'Refreshes the warehouse events materialized view. If migrate is true, then the materialized view will be migrated if necessary.'
     AS
 BEGIN
@@ -105,7 +105,7 @@ BEGIN
     EXCEPTION
         WHEN OTHER THEN
             ROLLBACK;
-            return OBJECT_CONSTRUCT('Error type', 'warehouse size mapping error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
+            return OBJECT_CONSTRUCT('Error type', 'warehouse size mapping error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate);
     END;
 
     SYSTEM$LOG_INFO('Finished warehouse size table refresh');

--- a/bootstrap/018_warehouse_updates.sql
+++ b/bootstrap/018_warehouse_updates.sql
@@ -1,5 +1,4 @@
 
-CREATE TABLE INTERNAL.TASK_WAREHOUSE_EVENTS IF NOT EXISTS (run timestamp, success boolean, input variant, output variant);
 CREATE TABLE INTERNAL.WAREHOUSE_SIZE_MAPPING IF NOT EXISTS (WAREHOUSE_NAME varchar, WAREHOUSE_SIZE varchar, WAREHOUSE_TYPE varchar);
 
 CREATE OR REPLACE PROCEDURE INTERNAL.MIGRATE_WAREHOUSE_SIZE_MAPPING()
@@ -34,7 +33,7 @@ begin
     return object_construct('migrate1', migrate1, 'migrate2', migrate2);
 end;
 
-CREATE OR REPLACE PROCEDURE internal.refresh_warehouse_events(migrate boolean) RETURNS STRING LANGUAGE SQL
+CREATE OR REPLACE PROCEDURE internal.refresh_warehouse_events(migrate boolean, input variant) RETURNS STRING LANGUAGE SQL
     COMMENT = 'Refreshes the warehouse events materialized view. If migrate is true, then the materialized view will be migrated if necessary.'
     AS
 BEGIN
@@ -49,10 +48,9 @@ BEGIN
         migrate2 := migrate_result:migrate2::string;
     end if;
 
-    let input variant := null;
+    let output variant := NULL;
     BEGIN
         BEGIN TRANSACTION;
-        input := (select output from INTERNAL.TASK_WAREHOUSE_EVENTS where success order by run desc limit 1);
         let oldest_running timestamp := 0::timestamp;
         let newest_completed timestamp := 0::timestamp;
 
@@ -82,9 +80,9 @@ BEGIN
             let where_clause_complete varchar := (select 'not incomplete and session_end <> to_timestamp_ltz(\'' || :newest_completed || '\')');
             let new_closed number;
             call internal.generate_insert_statement('INTERNAL_REPORTING_MV', 'CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY', 'INTERNAL', 'RAW_WH_EVT', :where_clause_complete) into :new_closed;
-            insert into INTERNAL.TASK_WAREHOUSE_EVENTS SELECT :run_id, true, :input, OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2, 'new_records', :new_records, 'new_INCOMPLETE', :new_INCOMPLETE, 'new_closed', coalesce(:new_closed, 0))::VARIANT;
+            output := OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2, 'new_records', :new_records, 'new_INCOMPLETE', :new_INCOMPLETE, 'new_closed', coalesce(:new_closed, 0))::VARIANT;
         ELSE
-            insert into INTERNAL.TASK_WAREHOUSE_EVENTS SELECT :dt, true, :input, OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2, 'new_records', 0, 'new_INCOMPLETE', 0, 'new_closed', 0)::VARIANT;
+            output := OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2, 'new_records', 0, 'new_INCOMPLETE', 0, 'new_closed', 0)::VARIANT;
         END IF;
         DROP TABLE RAW_WH_EVT;
         COMMIT;
@@ -93,10 +91,9 @@ BEGIN
       WHEN OTHER THEN
         SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Exception occurred while refreshing warehouse events.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
         ROLLBACK;
-        insert into INTERNAL.TASK_WAREHOUSE_EVENTS SELECT :dt, false, :input, OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
-        RAISE;
-
+        return OBJECT_CONSTRUCT('Error type', 'warehouse events error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
     END;
+
 
     SYSTEM$LOG_INFO('Starting warehouse size table refresh');
     BEGIN
@@ -105,9 +102,16 @@ BEGIN
             SHOW WAREHOUSES;
             insert into internal.warehouse_size_mapping select "name", "size", "type" from TABLE(RESULT_SCAN(LAST_QUERY_ID()));
         COMMIT;
+    EXCEPTION
+        WHEN OTHER THEN
+            ROLLBACK;
+            return OBJECT_CONSTRUCT('Error type', 'warehouse size mapping error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
     END;
+
     SYSTEM$LOG_INFO('Finished warehouse size table refresh');
     CALL INTERNAL.SET_CONFIG('WAREHOUSE_EVENTS_MAINTENANCE', CURRENT_TIMESTAMP()::string);
+
+    return output;
 END;
 
 CREATE OR REPLACE FUNCTION TOOLS.APPROX_CREDITS_USED(wh_name varchar, start_time timestamp, end_time timestamp)

--- a/bootstrap/018_warehouse_updates.sql
+++ b/bootstrap/018_warehouse_updates.sql
@@ -81,7 +81,7 @@ BEGIN
             let new_closed number;
             call internal.generate_insert_statement('INTERNAL_REPORTING_MV', 'CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY', 'INTERNAL', 'RAW_WH_EVT', :where_clause_complete) into :new_closed;
             -- Find oldest session, after the new records have been inserted.
-            let range_min timestamp_ltz := (select min(session_end) from (
+            let range_min timestamp := (select min(session_end) from (
                 select min(session_end) as session_end from INTERNAL_REPORTING_MV.CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY
                 union all
                 select min(session_end) as session_end from INTERNAL_REPORTING_MV.CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY_INCOMPLETE)
@@ -89,7 +89,7 @@ BEGIN
             output := OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2,
                 'new_records', :new_records, 'new_INCOMPLETE', :new_INCOMPLETE, 'new_closed', coalesce(:new_closed, 0), 'range_min', :range_min, 'range_max', :newest_completed);
         ELSE
-            let range_min timestamp_ltz := (select min(session_end) from (
+            let range_min timestamp := (select min(session_end) from (
                 select min(session_end) as session_end from INTERNAL_REPORTING_MV.CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY
                 union all
                 select min(session_end) as session_end from INTERNAL_REPORTING_MV.CLUSTER_AND_WAREHOUSE_SESSIONS_COMPLETE_AND_DAILY_INCOMPLETE

--- a/bootstrap/019_query_history_updates.sql
+++ b/bootstrap/019_query_history_updates.sql
@@ -63,9 +63,22 @@ BEGIN
             let where_clause_complete varchar := (select 'END_TIME <> to_timestamp_ltz(\'' || :newest_completed || '\')');
             let new_closed number;
             call internal.generate_insert_statement('INTERNAL_REPORTING_MV', 'QUERY_HISTORY_COMPLETE_AND_DAILY', 'INTERNAL', 'RAW_QH_EVT', :where_clause_complete) into :new_closed;
-            output := OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2, 'new_records', :new_records, 'new_INCOMPLETE', :new_INCOMPLETE, 'new_closed', coalesce(:new_closed, 0));
+            -- Figure out the oldest row in the table
+            let range_min timestamp_ltz := (select min(end_time) from (
+                select min(end_time) as end_time from internal_reporting_mv.QUERY_HISTORY_COMPLETE_AND_DAILY
+                union all
+                select min(end_time) as end_time from internal_reporting_mv.QUERY_HISTORY_COMPLETE_AND_DAILY_INCOMPLETE
+            ));
+            output := OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2,
+                'new_records', :new_records, 'new_INCOMPLETE', :new_INCOMPLETE, 'new_closed', coalesce(:new_closed, 0), 'range_min', :range_min, 'range_max', :newest_completed);
         ELSE
-            output := OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2, 'new_records', 0, 'new_INCOMPLETE', 0, 'new_closed', 0);
+            let range_min timestamp_ltz := (select min(end_time) from (
+                select min(end_time) as end_time from internal_reporting_mv.QUERY_HISTORY_COMPLETE_AND_DAILY
+                union all
+                select min(end_time) as end_time from internal_reporting_mv.QUERY_HISTORY_COMPLETE_AND_DAILY_INCOMPLETE
+            ));
+            output := OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2,
+                'new_records', 0, 'new_INCOMPLETE', 0, 'new_closed', 0, 'range_min', :range_min, 'range_max', :newest_completed);
         END IF;
         DROP TABLE RAW_QH_EVT;
         COMMIT;

--- a/bootstrap/019_query_history_updates.sql
+++ b/bootstrap/019_query_history_updates.sql
@@ -64,7 +64,7 @@ BEGIN
             let new_closed number;
             call internal.generate_insert_statement('INTERNAL_REPORTING_MV', 'QUERY_HISTORY_COMPLETE_AND_DAILY', 'INTERNAL', 'RAW_QH_EVT', :where_clause_complete) into :new_closed;
             -- Figure out the oldest row in the table
-            let range_min timestamp_ltz := (select min(end_time) from (
+            let range_min timestamp := (select min(end_time) from (
                 select min(end_time) as end_time from internal_reporting_mv.QUERY_HISTORY_COMPLETE_AND_DAILY
                 union all
                 select min(end_time) as end_time from internal_reporting_mv.QUERY_HISTORY_COMPLETE_AND_DAILY_INCOMPLETE
@@ -72,7 +72,7 @@ BEGIN
             output := OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2,
                 'new_records', :new_records, 'new_INCOMPLETE', :new_INCOMPLETE, 'new_closed', coalesce(:new_closed, 0), 'range_min', :range_min, 'range_max', :newest_completed);
         ELSE
-            let range_min timestamp_ltz := (select min(end_time) from (
+            let range_min timestamp := (select min(end_time) from (
                 select min(end_time) as end_time from internal_reporting_mv.QUERY_HISTORY_COMPLETE_AND_DAILY
                 union all
                 select min(end_time) as end_time from internal_reporting_mv.QUERY_HISTORY_COMPLETE_AND_DAILY_INCOMPLETE

--- a/bootstrap/019_query_history_updates.sql
+++ b/bootstrap/019_query_history_updates.sql
@@ -76,6 +76,6 @@ BEGIN
       WHEN OTHER THEN
         SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Exception occurred while refreshing query history.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
         ROLLBACK;
-        return OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
+        return OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate);
     END;
 END;

--- a/bootstrap/019_query_history_updates.sql
+++ b/bootstrap/019_query_history_updates.sql
@@ -1,6 +1,4 @@
 
-CREATE TABLE INTERNAL.TASK_QUERY_HISTORY IF NOT EXISTS (run timestamp, success boolean, input variant, output variant);
-
 CREATE OR REPLACE PROCEDURE internal.migrate_queries()
 returns variant
 language sql
@@ -21,9 +19,8 @@ begin
     return object_construct('migrate1', migrate1, 'migrate2', migrate2);
 end;
 
-CREATE OR REPLACE PROCEDURE internal.refresh_queries(migrate boolean) RETURNS STRING LANGUAGE SQL AS
+CREATE OR REPLACE PROCEDURE internal.refresh_queries(migrate boolean, input variant) RETURNS OBJECT LANGUAGE SQL AS
 BEGIN
-    let dt timestamp := current_timestamp();
     SYSTEM$LOG_INFO('Starting refresh queries.');
     let migrate1 string := null;
     let migrate2 string := null;
@@ -34,10 +31,8 @@ BEGIN
         migrate2 := migration_result:migrate2::string;
     end if;
 
-    let input variant := null;
     BEGIN
         BEGIN TRANSACTION;
-        input := (select output from INTERNAL.TASK_QUERY_HISTORY where success order by run desc limit 1);
         let oldest_running timestamp := 0::timestamp;
         let newest_completed timestamp := 0::timestamp;
 
@@ -55,6 +50,7 @@ BEGIN
         CREATE TABLE RAW_QH_EVT AS SELECT * FROM INTERNAL_REPORTING.QUERY_HISTORY_COMPLETE_AND_DAILY WHERE filterts >= :oldest_running AND end_time >= :newest_completed;
         let new_records number := (select count(*) from RAW_QH_EVT);
 
+        let output variant := null;
         IF (new_records > 0) THEN
             -- if there are incomplete queries, find the min timestamp of the incomplete queries. If there are no incomplete, find the newest timestamp for a filter condition next time.
             oldest_running := (SELECT greatest(coalesce(MIN(case when incomplete then filterts else null end), max(end_time)), :oldest_running) FROM RAW_QH_EVT);
@@ -67,20 +63,19 @@ BEGIN
             let where_clause_complete varchar := (select 'END_TIME <> to_timestamp_ltz(\'' || :newest_completed || '\')');
             let new_closed number;
             call internal.generate_insert_statement('INTERNAL_REPORTING_MV', 'QUERY_HISTORY_COMPLETE_AND_DAILY', 'INTERNAL', 'RAW_QH_EVT', :where_clause_complete) into :new_closed;
-            insert into INTERNAL.TASK_QUERY_HISTORY SELECT :run_id, true, :input, OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2, 'new_records', :new_records, 'new_INCOMPLETE', :new_INCOMPLETE, 'new_closed', coalesce(:new_closed, 0))::VARIANT;
+            output := OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2, 'new_records', :new_records, 'new_INCOMPLETE', :new_INCOMPLETE, 'new_closed', coalesce(:new_closed, 0));
         ELSE
-            insert into INTERNAL.TASK_QUERY_HISTORY SELECT :dt, true, :input, OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2, 'new_records', 0, 'new_INCOMPLETE', 0, 'new_closed', 0)::VARIANT;
+            output := OBJECT_CONSTRUCT('oldest_running', :oldest_running, 'newest_completed', :newest_completed, 'attempted_migrate', :migrate, 'migrate', :migrate1, 'migrate_INCOMPLETE', :migrate2, 'new_records', 0, 'new_INCOMPLETE', 0, 'new_closed', 0);
         END IF;
         DROP TABLE RAW_QH_EVT;
         COMMIT;
 
+        CALL INTERNAL.SET_CONFIG('QUERY_HISTORY_MAINTENANCE', CURRENT_TIMESTAMP()::string);
+        return output;
     EXCEPTION
       WHEN OTHER THEN
         SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Exception occurred while refreshing query history.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
         ROLLBACK;
-        insert into INTERNAL.TASK_QUERY_HISTORY SELECT :dt, false, :input, OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
-        RAISE;
-
+        return OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
     END;
-    CALL INTERNAL.SET_CONFIG('QUERY_HISTORY_MAINTENANCE', CURRENT_TIMESTAMP()::string);
 END;

--- a/bootstrap/023_simple_materializations.sql
+++ b/bootstrap/023_simple_materializations.sql
@@ -53,8 +53,9 @@ BEGIN
         let where_clause_complete varchar := (select :index_col || ' >= to_timestamp_ltz(\'' || :oldest_running || '\')');
         let new_closed number;
         call internal.generate_insert_statement('INTERNAL_REPORTING_MV', :table_name, 'ACCOUNT_USAGE', :table_name, :where_clause_complete) into :new_closed;
+        let range_min timestamp := (select min(identifier(:index_col)) from identifier(:table_ident));
         let new_running timestamp := (select max(identifier(:index_col)) from identifier(:table_ident));
-        output := OBJECT_CONSTRUCT('oldest_running', :new_running, 'attempted_migrate', :migrate, 'new_records', coalesce(:new_closed, 0));
+        output := OBJECT_CONSTRUCT('oldest_running', :new_running, 'attempted_migrate', :migrate, 'new_records', coalesce(:new_closed, 0), 'range_min', :range_min, 'range_max', :new_running);
         COMMIT;
 
     EXCEPTION

--- a/bootstrap/023_simple_materializations.sql
+++ b/bootstrap/023_simple_materializations.sql
@@ -11,12 +11,6 @@ BEGIN
     COMMIT;
 END;
 
-CREATE TABLE INTERNAL.TASK_SIMPLE_DATA_EVENTS IF NOT EXISTS (run timestamp, success boolean, table_name varchar, input variant, output variant);
-CREATE TABLE INTERNAL.TASK_WAREHOUSE_LOAD_EVENTS IF NOT EXISTS (run timestamp, success boolean, warehouse_name varchar, input variant, output variant);
-
-CREATE OR REPLACE VIEW REPORTING.SIMPLE_DATA_EVENTS_TASK_HISTORY AS SELECT * FROM INTERNAL.TASK_SIMPLE_DATA_EVENTS;
-CREATE OR REPLACE VIEW REPORTING.WAREHOUSE_LOAD_EVENTS_TASK_HISTORY AS SELECT * FROM INTERNAL.TASK_WAREHOUSE_LOAD_EVENTS;
-
 CREATE OR REPLACE PROCEDURE internal.migrate_events(table_name varchar)
 returns variant
 language sql
@@ -29,11 +23,10 @@ begin
     return object_construct('migrate1', migrate1);
 end;
 
-CREATE OR REPLACE PROCEDURE internal.refresh_simple_table(table_name varchar, index_col varchar, migrate boolean) RETURNS STRING LANGUAGE SQL
+CREATE OR REPLACE PROCEDURE internal.refresh_simple_table(table_name varchar, index_col varchar, migrate boolean, input variant) RETURNS STRING LANGUAGE SQL
     COMMENT = 'Refreshes the materialized view for a given table. If migrate is true, then the materialized view will be migrated if necessary.'
     AS
 BEGIN
-    let dt timestamp := current_timestamp();
     SYSTEM$LOG_INFO('Starting refresh ' || :table_name || ' events.');
     let migrate1 string := null;
     if (migrate) then
@@ -42,10 +35,9 @@ BEGIN
         migrate1 := migrate_result:migrate1::string;
     end if;
 
-    let input variant := null;
+    let output variant := null;
     BEGIN
         BEGIN TRANSACTION;
-        input := (select output from INTERNAL.TASK_SIMPLE_DATA_EVENTS where success and table_name = :table_name order by run desc limit 1);
         let oldest_running timestamp := 0::timestamp;
 
         if (input is not null) then
@@ -62,17 +54,17 @@ BEGIN
         let new_closed number;
         call internal.generate_insert_statement('INTERNAL_REPORTING_MV', :table_name, 'ACCOUNT_USAGE', :table_name, :where_clause_complete) into :new_closed;
         let new_running timestamp := (select max(identifier(:index_col)) from identifier(:table_ident));
-        insert into INTERNAL.TASK_SIMPLE_DATA_EVENTS SELECT :dt, true, :table_name, :input, OBJECT_CONSTRUCT('oldest_running', :new_running, 'attempted_migrate', :migrate, 'new_records', coalesce(:new_closed, 0))::VARIANT;
+        output := OBJECT_CONSTRUCT('oldest_running', :new_running, 'attempted_migrate', :migrate, 'new_records', coalesce(:new_closed, 0))::VARIANT;
         COMMIT;
 
     EXCEPTION
       WHEN OTHER THEN
         SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Exception occurred while refreshing ' || :table_name || ' events.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
         ROLLBACK;
-        insert into INTERNAL.TASK_SIMPLE_DATA_EVENTS SELECT :dt, false, :table_name, :input, OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
-        RAISE;
-
+        output := OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
     END;
+
+    return output;
 end;
 
 create or replace procedure internal.migrate_simple_data_view(table_name varchar) returns variant language sql as
@@ -120,32 +112,24 @@ CREATE TABLE IF NOT EXISTS internal_reporting_mv.warehouse_load_history (start_t
 create or replace view reporting.warehouse_load_history as select * from internal_reporting_mv.warehouse_load_history;
 
 
-CREATE OR REPLACE PROCEDURE internal.refresh_one_warehouse_load_history(warehouse_name varchar) RETURNS table(sql varchar) LANGUAGE SQL
+CREATE OR REPLACE PROCEDURE internal.refresh_one_warehouse_load_history(warehouse_name varchar, input variant) RETURNS table(sql varchar) LANGUAGE SQL
     AS
 begin
-    let dt timestamp := current_timestamp();
+    let oldest_running timestamp := 0::timestamp;
 
-    let input variant := null;
-    BEGIN
-        input := (select output from INTERNAL.TASK_WAREHOUSE_LOAD_EVENTS where success and warehouse_name = :warehouse_name order by run desc limit 1);
-        let oldest_running timestamp := 0::timestamp;
+    if (input is not null) then
+        oldest_running := coalesce(input:oldest_running::timestamp, 0::timestamp);
+    end if;
 
-        if (input is not null) then
-            oldest_running := coalesce(input:oldest_running::timestamp, 0::timestamp);
-        end if;
+    let stmt varchar := 'insert into internal_reporting_mv.warehouse_load_history select start_time, end_time, warehouse_name, avg_running, avg_queued_load, avg_queued_provisioning, avg_blocked from table(information_schema.warehouse_load_history(date_range_start => to_timestamp_ltz(\'{start_time}\'), date_range_end => to_timestamp_ltz(\'{end_time}\'), warehouse_name => \'"{warehouse_name}"\'))';
+    let start_time timestamp := (select greatest(:oldest_running, dateadd(day, -14, current_timestamp())));
+    let res resultset := (select tools.templatejs(:stmt,
+        {
+          'warehouse_name': :warehouse_name,
+          'start_time': dateadd(hours, value, :start_time)::text,
+          'end_time': dateadd(hours, value+8, :start_time)::text
+        })
+    from table(flatten(input=>array_generate_range(0, datediff(hours, :start_time, current_timestamp()), 8))) f);
 
-        let stmt varchar := 'insert into internal_reporting_mv.warehouse_load_history select start_time, end_time, warehouse_name, avg_running, avg_queued_load, avg_queued_provisioning, avg_blocked from table(information_schema.warehouse_load_history(date_range_start => to_timestamp_ltz(\'{start_time}\'), date_range_end => to_timestamp_ltz(\'{end_time}\'), warehouse_name => \'"{warehouse_name}"\'))';
-        let start_time timestamp := (select greatest(:oldest_running, dateadd(day, -14, current_timestamp())));
-        let res resultset := (select tools.templatejs(:stmt,
-            {
-              'warehouse_name': :warehouse_name,
-              'start_time': dateadd(hours, value, :start_time)::text,
-              'end_time': dateadd(hours, value+8, :start_time)::text
-            })
-        from table(flatten(input=>array_generate_range(0, datediff(hours, :start_time, current_timestamp()), 8))) f);
-
-        return table(res);
-
-
-    END;
+    return table(res);
 end;

--- a/bootstrap/023_simple_materializations.sql
+++ b/bootstrap/023_simple_materializations.sql
@@ -113,7 +113,7 @@ CREATE TABLE IF NOT EXISTS internal_reporting_mv.warehouse_load_history (start_t
 create or replace view reporting.warehouse_load_history as select * from internal_reporting_mv.warehouse_load_history;
 
 
-CREATE OR REPLACE PROCEDURE internal.refresh_one_warehouse_load_history(warehouse_name varchar, input variant) RETURNS table(sql varchar) LANGUAGE SQL
+CREATE OR REPLACE PROCEDURE internal.refresh_one_warehouse_load_history(warehouse_name varchar, input object) RETURNS table(sql varchar) LANGUAGE SQL
     AS
 begin
     let oldest_running timestamp := 0::timestamp;

--- a/bootstrap/023_simple_materializations.sql
+++ b/bootstrap/023_simple_materializations.sql
@@ -23,7 +23,7 @@ begin
     return object_construct('migrate1', migrate1);
 end;
 
-CREATE OR REPLACE PROCEDURE internal.refresh_simple_table(table_name varchar, index_col varchar, migrate boolean, input variant) RETURNS VARIANT LANGUAGE SQL
+CREATE OR REPLACE PROCEDURE internal.refresh_simple_table(table_name varchar, index_col varchar, migrate boolean, input variant) RETURNS OBJECT LANGUAGE SQL
     COMMENT = 'Refreshes the materialized view for a given table. If migrate is true, then the materialized view will be migrated if necessary.'
     AS
 BEGIN

--- a/bootstrap/050_settings.sql
+++ b/bootstrap/050_settings.sql
@@ -129,8 +129,7 @@ CREATE OR REPLACE PROCEDURE ADMIN.RELOAD_QUERY_HISTORY()
 AS
 BEGIN
     SYSTEM$LOG_INFO('Reloading query history and warehouse events data');
-    truncate table internal.task_query_history;
-    truncate table internal.task_warehouse_events;
+    truncate table internal.task_log;
     truncate table internal_reporting_mv.cluster_and_warehouse_sessions_complete_and_daily;
     truncate table internal_reporting_mv.query_history_complete_and_daily;
     call internal.refresh_warehouse_events(true);

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -71,7 +71,7 @@ CREATE OR REPLACE TASK TASKS.WAREHOUSE_EVENTS_MAINTENANCE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "XSMALL"
     AS
 DECLARE
-    start_time timestamp_ltz default (select current_timestamp());
+    start_time text default (select current_timestamp()::TEXT);
     root_task_id text default (select INTERNAL.ROOT_TASK_ID());
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
     task_name text default 'WAREHOUSE_EVENTS_MAINTENANCE';
@@ -117,7 +117,7 @@ BEGIN
         let table_name text := rowvar.table_name;
         let index_col text := rowvar.index_col;
         BEGIN
-            let start_time timestamp_ltz := (select current_timestamp());
+            let start_time text := (select current_timestamp()::TEXT);
             let input object;
             CALL INTERNAL.START_TASK(:task_name, :table_name, :start_time, :task_run_id, :query_id) into input;
 
@@ -138,7 +138,7 @@ CREATE OR REPLACE TASK TASKS.QUERY_HISTORY_MAINTENANCE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "LARGE"
     AS
 DECLARE
-    start_time timestamp_ltz default (select current_timestamp());
+    start_time text default (select current_timestamp()::TEXT);
     task_name text default 'QUERY_HISTORY_MAINTENANCE';
     object_name text default 'QUERY_HISTORY';
     root_task_id text default (select INTERNAL.ROOT_TASK_ID());
@@ -380,7 +380,7 @@ CREATE OR REPLACE TASK TASKS.WAREHOUSE_LOAD_MAINTENANCE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "XSMALL"
     AS
 DECLARE
-    task_start timestamp_ltz default (select current_timestamp());
+    task_start text default (select current_timestamp()::TEXT);
     task_name text default 'WAREHOUSE_LOAD_MAINTENANCE';
     root_task_id text default (select INTERNAL.ROOT_TASK_ID());
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
@@ -390,7 +390,7 @@ BEGIN
     let wh resultset := (select name from internal.sfwarehouses);
     let wh_cur cursor for wh;
     for wh_row in wh_cur do
-        let start_time timestamp_ltz := (select current_timestamp());
+        let start_time text := (select current_timestamp()::TEXT);
         let wh_name varchar := wh_row.name;
         let output object;
         let input object;

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -70,21 +70,84 @@ CREATE OR REPLACE TASK TASKS.WAREHOUSE_EVENTS_MAINTENANCE
     ALLOW_OVERLAPPING_EXECUTION = FALSE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "XSMALL"
     AS
-    CALL INTERNAL.refresh_warehouse_events(true);
+DECLARE
+    start_time timestamp_ltz default (select current_timestamp());
+    task_run_id text default (select INTERNAL.TASK_RUN_ID());
+    query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'WAREHOUSE_EVENTS_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
+    object_type text default 'WAREHOUSE_EVENTS';
+    object_name text default 'WAREHOUSE_EVENTS_HISTORY';
+BEGIN
+    let input variant := (select output from INTERNAL.TASK_LOG where success AND object_type = :object_type AND object_name = :object_name order by task_start desc limit 1);
+    INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, object_type, object_name) select :start_time, :task_run_id, :query_id, :input, :object_type, :object_name;
+
+    let output variant;
+    CALL INTERNAL.refresh_warehouse_events(true, :input) into :output;
+
+    let success boolean := (select :output['SQLERRM'] is null);
+    UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id;
+END;
 
 CREATE OR REPLACE TASK TASKS.SIMPLE_DATA_EVENTS_MAINTENANCE
     SCHEDULE = '60 minute'
     ALLOW_OVERLAPPING_EXECUTION = FALSE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "XSMALL"
     AS
-    CALL INTERNAL.refresh_all_simple_tables(true);
+DECLARE
+    object_type text default 'SIMPLE_DATA_EVENT';
+    task_run_id text default (select INTERNAL.TASK_RUN_ID());
+    query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'SIMPLE_DATA_EVENTS_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
+BEGIN
+    let simple_tables resultset := (SELECT t.table_name, t.index_col FROM (VALUES
+        ('SERVERLESS_TASK_HISTORY', 'end_time'),
+        ('TASK_HISTORY', 'completed_time'),
+        ('SESSIONS', 'created_on'),
+        ('WAREHOUSE_METERING_HISTORY', 'end_time'),
+        ('LOGIN_HISTORY', 'event_timestamp'),
+        ('HYBRID_TABLE_USAGE_HISTORY', 'end_time'),
+        ('MATERIALIZED_VIEW_REFRESH_HISTORY', 'end_time')
+    ) AS t(table_name, index_col));
+    let cur cursor for simple_tables;
+    FOR rowvar IN cur DO
+        let table_name text := rowvar.table_name;
+        let index_col text := rowvar.index_col;
+        BEGIN
+            let start_time timestamp_ltz := (select current_timestamp());
+            let input object := (select output from INTERNAL.TASK_LOG where success and object_type = :object_type and object_name = :table_name order by task_start desc limit 1);
+            INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, object_type, object_name) select :start_time, :task_run_id, :query_id, :input, :object_type, :table_name;
+
+            let output variant;
+            CALL INTERNAL.refresh_simple_table(:table_name, :index_col, true, :input) into :output;
+
+            let success boolean := (select :output['SQLERRM'] is null);
+            UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id and object_type = :object_type AND object_name = :table_name;
+        END;
+    END FOR;
+
+    -- TODO add table log
+    call internal.refresh_warehouses();
+END;
 
 CREATE OR REPLACE TASK TASKS.QUERY_HISTORY_MAINTENANCE
     SCHEDULE = '60 minute'
     ALLOW_OVERLAPPING_EXECUTION = FALSE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "LARGE"
     AS
-    CALL INTERNAL.refresh_queries(true);
+DECLARE
+    start_time timestamp_ltz default (select current_timestamp());
+    object_type text default 'QUERY_HISTORY';
+    object_name text default 'QUERY_HISTORY';
+    task_run_id text default (select INTERNAL.TASK_RUN_ID());
+    query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'QUERY_HISTORY_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
+BEGIN
+    let input variant := (select output from INTERNAL.TASK_LOG where success AND object_type = :object_type AND object_name = :object_name order by task_start desc limit 1);
+    INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, object_type, object_name) select :start_time, :task_run_id, :query_id, :input, :object_type, :object_name;
+
+    let output variant;
+    CALL INTERNAL.refresh_queries(true, :input) into :output;
+
+    let success boolean := (select :output['SQLERRM'] is null);
+    UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id AND object_type = :object_type AND object_name = :object_name;
+END;
 
 CREATE OR REPLACE TASK TASKS.SFUSER_MAINTENANCE
     SCHEDULE = '1440 minute'
@@ -311,15 +374,24 @@ CREATE OR REPLACE TASK TASKS.WAREHOUSE_LOAD_MAINTENANCE
     ALLOW_OVERLAPPING_EXECUTION = FALSE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "XSMALL"
     AS
+DECLARE
+    task_start timestamp_ltz default (select current_timestamp());
+    object_type text default 'WAREHOUSE_LOAD_EVENT';
+    task_run_id text default (select INTERNAL.TASK_RUN_ID());
+    query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'WAREHOUSE_LOAD_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
 BEGIN
-    let dt timestamp := current_timestamp();
     let wh resultset := (select name from internal.sfwarehouses);
     let wh_cur cursor for wh;
     for wh_row in wh_cur do
+        let start_time timestamp_ltz := (select current_timestamp());
         let wh_name varchar := wh_row.name;
-        let input variant := (select output from INTERNAL.TASK_WAREHOUSE_LOAD_EVENTS where success and warehouse_name = :wh_name order by run desc limit 1);
+        let output variant;
+        let input variant := (select output from INTERNAL.TASK_LOG where success and object_type = :object_type and object_name = :wh_name order by task_start desc limit 1);
+        INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, object_type, object_name) select :start_time, :task_run_id, :query_id, :input, :object_type, :wh_name;
+
+        -- We have to run the warehouse load history query in the task and not in a procedure call by the task. The below block is our "task body".
         begin
-            let stmt resultset := (call internal.refresh_one_warehouse_load_history(:wh_name));
+            let stmt resultset := (call internal.refresh_one_warehouse_load_history(:wh_name, :input));
             let stmt_cur cursor for stmt;
             let total_inserted_rows number := 0;
             for stmt_row in stmt_cur do
@@ -329,19 +401,21 @@ BEGIN
                 total_inserted_rows := total_inserted_rows + new_inserted_rows;
             end for;
             let new_running timestamp := (select max(end_time) from internal_reporting_mv.warehouse_load_history where warehouse_name = :wh_name);
-            insert into INTERNAL.TASK_WAREHOUSE_LOAD_EVENTS SELECT :dt, true, :wh_name, :input, OBJECT_CONSTRUCT('oldest_running', :new_running, 'new_records', coalesce(:total_inserted_rows, 0))::VARIANT;
+            output := OBJECT_CONSTRUCT('oldest_running', :new_running, 'new_records', coalesce(:total_inserted_rows, 0))::VARIANT;
         exception
             when other then
                 SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Exception occurred while refreshing ' || :wh_name || ' events.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
-                insert into INTERNAL.TASK_WAREHOUSE_LOAD_EVENTS SELECT :dt, false, :wh_name, :input, OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
-                RAISE;
+                output := OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
         end;
+
+        let success boolean := (select :output['SQLERRM'] is null);
+        UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id AND object_type = :object_type AND object_name = :wh_name;
     end for;
 
 exception
     when other then
         SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Exception occurred while refreshing all warehouse events.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
-        insert into INTERNAL.TASK_WAREHOUSE_LOAD_EVENTS SELECT :dt, false, 'all', null, OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
+        insert into INTERNAL.TASK_LOG(task_start, success, object_name, input, output, task_run_id, query_id, object_type, object_name) SELECT :task_start, false, 'all', null, OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant, :task_run_id, :query_id, :object_type;
         RAISE;
 end;
 

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -401,11 +401,11 @@ BEGIN
                 total_inserted_rows := total_inserted_rows + new_inserted_rows;
             end for;
             let new_running timestamp := (select max(end_time) from internal_reporting_mv.warehouse_load_history where warehouse_name = :wh_name);
-            output := OBJECT_CONSTRUCT('oldest_running', :new_running, 'new_records', coalesce(:total_inserted_rows, 0))::VARIANT;
+            output := OBJECT_CONSTRUCT('oldest_running', :new_running, 'new_records', coalesce(:total_inserted_rows, 0));
         exception
             when other then
                 SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Exception occurred while refreshing ' || :wh_name || ' events.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
-                output := OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant;
+                output := OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate);
         end;
 
         let success boolean := (select :output['SQLERRM'] is null);

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -85,6 +85,11 @@ BEGIN
     CALL INTERNAL.refresh_warehouse_events(true, :input) into :output;
 
     CALL INTERNAL.FINISH_TASK(:task_name, :object_name, :start_time, :task_run_id, :output);
+
+    -- Warehouse events history is a special case where we want to distinctly track warehouse sessions and cluster sessions
+    -- but not change the existing materialization logic which materializes both at the same time.
+    -- We create a task-level row using the typical API above, but then create domain-specific rows below.
+    CALL INTERNAL.FINISH_WAREHOUSE_EVENTS_TASK(:task_name, :start_time, :task_run_id, :query_id, :input, :output);
 END;
 
 CREATE OR REPLACE TASK TASKS.SIMPLE_DATA_EVENTS_MAINTENANCE

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -74,11 +74,11 @@ DECLARE
     start_time timestamp_ltz default (select current_timestamp());
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
     query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'WAREHOUSE_EVENTS_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
-    object_type text default 'WAREHOUSE_EVENTS';
+    task_name text default 'WAREHOUSE_EVENTS';
     object_name text default 'WAREHOUSE_EVENTS_HISTORY';
 BEGIN
-    let input variant := (select output from INTERNAL.TASK_LOG where success AND object_type = :object_type AND object_name = :object_name order by task_start desc limit 1);
-    INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, object_type, object_name) select :start_time, :task_run_id, :query_id, :input, :object_type, :object_name;
+    let input variant := (select output from INTERNAL.TASK_LOG where success AND task_name = :task_name AND object_name = :object_name order by task_start desc limit 1);
+    INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, task_name, object_name) select :start_time, :task_run_id, :query_id, :input, :task_name, :object_name;
 
     let output variant;
     CALL INTERNAL.refresh_warehouse_events(true, :input) into :output;
@@ -93,7 +93,7 @@ CREATE OR REPLACE TASK TASKS.SIMPLE_DATA_EVENTS_MAINTENANCE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "XSMALL"
     AS
 DECLARE
-    object_type text default 'SIMPLE_DATA_EVENT';
+    task_name text default 'SIMPLE_DATA_EVENTS_MAINTENANCE';
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
     query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'SIMPLE_DATA_EVENTS_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
 BEGIN
@@ -112,14 +112,14 @@ BEGIN
         let index_col text := rowvar.index_col;
         BEGIN
             let start_time timestamp_ltz := (select current_timestamp());
-            let input object := (select output from INTERNAL.TASK_LOG where success and object_type = :object_type and object_name = :table_name order by task_start desc limit 1);
-            INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, object_type, object_name) select :start_time, :task_run_id, :query_id, :input, :object_type, :table_name;
+            let input object := (select output from INTERNAL.TASK_LOG where success and task_name = :task_name and object_name = :table_name order by task_start desc limit 1);
+            INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, task_name, object_name) select :start_time, :task_run_id, :query_id, :input, :task_name, :table_name;
 
             let output variant;
             CALL INTERNAL.refresh_simple_table(:table_name, :index_col, true, :input) into :output;
 
             let success boolean := (select :output['SQLERRM'] is null);
-            UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id and object_type = :object_type AND object_name = :table_name;
+            UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id and task_name = :task_name AND object_name = :table_name;
         END;
     END FOR;
 
@@ -134,19 +134,19 @@ CREATE OR REPLACE TASK TASKS.QUERY_HISTORY_MAINTENANCE
     AS
 DECLARE
     start_time timestamp_ltz default (select current_timestamp());
-    object_type text default 'QUERY_HISTORY';
+    task_name text default 'QUERY_HISTORY_MAINTENANCE';
     object_name text default 'QUERY_HISTORY';
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
     query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'QUERY_HISTORY_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
 BEGIN
-    let input variant := (select output from INTERNAL.TASK_LOG where success AND object_type = :object_type AND object_name = :object_name order by task_start desc limit 1);
-    INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, object_type, object_name) select :start_time, :task_run_id, :query_id, :input, :object_type, :object_name;
+    let input variant := (select output from INTERNAL.TASK_LOG where success AND task_name = :task_name AND object_name = :object_name order by task_start desc limit 1);
+    INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, task_name, object_name) select :start_time, :task_run_id, :query_id, :input, :task_name, :object_name;
 
     let output variant;
     CALL INTERNAL.refresh_queries(true, :input) into :output;
 
     let success boolean := (select :output['SQLERRM'] is null);
-    UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id AND object_type = :object_type AND object_name = :object_name;
+    UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id AND task_name = :task_name AND object_name = :object_name;
 END;
 
 CREATE OR REPLACE TASK TASKS.SFUSER_MAINTENANCE
@@ -376,7 +376,7 @@ CREATE OR REPLACE TASK TASKS.WAREHOUSE_LOAD_MAINTENANCE
     AS
 DECLARE
     task_start timestamp_ltz default (select current_timestamp());
-    object_type text default 'WAREHOUSE_LOAD_EVENT';
+    task_name text default 'WAREHOUSE_LOAD_MAINTENANCE';
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
     query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'WAREHOUSE_LOAD_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
 BEGIN
@@ -386,8 +386,8 @@ BEGIN
         let start_time timestamp_ltz := (select current_timestamp());
         let wh_name varchar := wh_row.name;
         let output variant;
-        let input variant := (select output from INTERNAL.TASK_LOG where success and object_type = :object_type and object_name = :wh_name order by task_start desc limit 1);
-        INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, object_type, object_name) select :start_time, :task_run_id, :query_id, :input, :object_type, :wh_name;
+        let input variant := (select output from INTERNAL.TASK_LOG where success and task_name = :task_name and object_name = :wh_name order by task_start desc limit 1);
+        INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, task_name, object_name) select :start_time, :task_run_id, :query_id, :input, :task_name, :wh_name;
 
         -- We have to run the warehouse load history query in the task and not in a procedure call by the task. The below block is our "task body".
         begin
@@ -409,13 +409,13 @@ BEGIN
         end;
 
         let success boolean := (select :output['SQLERRM'] is null);
-        UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id AND object_type = :object_type AND object_name = :wh_name;
+        UPDATE INTERNAL.TASK_LOG SET success = :success, output = :output, task_finish = current_timestamp() WHERE task_start = :start_time AND task_run_id = :task_run_id AND task_name = :task_name AND object_name = :wh_name;
     end for;
 
 exception
     when other then
         SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Exception occurred while refreshing all warehouse events.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
-        insert into INTERNAL.TASK_LOG(task_start, success, object_name, input, output, task_run_id, query_id, object_type, object_name) SELECT :task_start, false, 'all', null, OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant, :task_run_id, :query_id, :object_type;
+        insert into INTERNAL.TASK_LOG(task_start, success, object_name, input, output, task_run_id, query_id, task_name) SELECT :task_start, false, 'all', null, OBJECT_CONSTRUCT('Error type', 'Other error', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate)::variant, :task_run_id, :query_id, :task_name;
         RAISE;
 end;
 

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -71,7 +71,7 @@ CREATE OR REPLACE TASK TASKS.WAREHOUSE_EVENTS_MAINTENANCE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "XSMALL"
     AS
 DECLARE
-    start_time text default (select current_timestamp()::TEXT);
+    start_time timestamp_ntz default (select current_timestamp()::TIMESTAMP_NTZ);
     root_task_id text default (select INTERNAL.ROOT_TASK_ID());
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
     task_name text default 'WAREHOUSE_EVENTS_MAINTENANCE';
@@ -117,7 +117,7 @@ BEGIN
         let table_name text := rowvar.table_name;
         let index_col text := rowvar.index_col;
         BEGIN
-            let start_time text := (select current_timestamp()::TEXT);
+            let start_time TIMESTAMP_NTZ := (select current_timestamp()::TIMESTAMP_NTZ);
             let input object;
             CALL INTERNAL.START_TASK(:task_name, :table_name, :start_time, :task_run_id, :query_id) into input;
 
@@ -138,7 +138,7 @@ CREATE OR REPLACE TASK TASKS.QUERY_HISTORY_MAINTENANCE
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "LARGE"
     AS
 DECLARE
-    start_time text default (select current_timestamp()::TEXT);
+    start_time timestamp_ntz default (select current_timestamp()::TIMESTAMP_NTZ);
     task_name text default 'QUERY_HISTORY_MAINTENANCE';
     object_name text default 'QUERY_HISTORY';
     root_task_id text default (select INTERNAL.ROOT_TASK_ID());
@@ -390,7 +390,7 @@ BEGIN
     let wh resultset := (select name from internal.sfwarehouses);
     let wh_cur cursor for wh;
     for wh_row in wh_cur do
-        let start_time text := (select current_timestamp()::TEXT);
+        let start_time timestamp_ntz := (select current_timestamp()::TIMESTAMP_NTZ);
         let wh_name varchar := wh_row.name;
         let output object;
         let input object;

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -73,10 +73,10 @@ CREATE OR REPLACE TASK TASKS.WAREHOUSE_EVENTS_MAINTENANCE
 DECLARE
     start_time timestamp_ltz default (select current_timestamp());
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
-    query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'WAREHOUSE_EVENTS_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
     task_name text default 'WAREHOUSE_EVENTS_MAINTENANCE';
     object_name text default 'WAREHOUSE_EVENTS_HISTORY';
 BEGIN
+    let query_id text := (select query_id from table(information_schema.task_history(TASK_NAME => :task_name)) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
     let input variant := (select output from INTERNAL.TASK_LOG where success AND task_name = :task_name AND object_name = :object_name order by task_start desc limit 1);
     INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, task_name, object_name) select :start_time, :task_run_id, :query_id, :input, :task_name, :object_name;
 
@@ -95,8 +95,8 @@ CREATE OR REPLACE TASK TASKS.SIMPLE_DATA_EVENTS_MAINTENANCE
 DECLARE
     task_name text default 'SIMPLE_DATA_EVENTS_MAINTENANCE';
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
-    query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'SIMPLE_DATA_EVENTS_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
 BEGIN
+    let query_id text := (select query_id from table(information_schema.task_history(TASK_NAME => :task_name)) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
     let simple_tables resultset := (SELECT t.table_name, t.index_col FROM (VALUES
         ('SERVERLESS_TASK_HISTORY', 'end_time'),
         ('TASK_HISTORY', 'completed_time'),
@@ -137,8 +137,8 @@ DECLARE
     task_name text default 'QUERY_HISTORY_MAINTENANCE';
     object_name text default 'QUERY_HISTORY';
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
-    query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'QUERY_HISTORY_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
 BEGIN
+    let query_id text := (select query_id from table(information_schema.task_history(TASK_NAME => :task_name)) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
     let input variant := (select output from INTERNAL.TASK_LOG where success AND task_name = :task_name AND object_name = :object_name order by task_start desc limit 1);
     INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, task_name, object_name) select :start_time, :task_run_id, :query_id, :input, :task_name, :object_name;
 
@@ -378,8 +378,8 @@ DECLARE
     task_start timestamp_ltz default (select current_timestamp());
     task_name text default 'WAREHOUSE_LOAD_MAINTENANCE';
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
-    query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'WAREHOUSE_LOAD_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
 BEGIN
+    let query_id text := (select query_id from table(information_schema.task_history(TASK_NAME => :task_name)) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
     let wh resultset := (select name from internal.sfwarehouses);
     let wh_cur cursor for wh;
     for wh_row in wh_cur do

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -400,8 +400,9 @@ BEGIN
                 let new_inserted_rows number := (select * from TABLE(RESULT_SCAN(LAST_QUERY_ID())));
                 total_inserted_rows := total_inserted_rows + new_inserted_rows;
             end for;
+            let range_min timestamp := (select min(end_time) from internal_reporting_mv.warehouse_load_history where warehouse_name = :wh_name);
             let new_running timestamp := (select max(end_time) from internal_reporting_mv.warehouse_load_history where warehouse_name = :wh_name);
-            output := OBJECT_CONSTRUCT('oldest_running', :new_running, 'new_records', coalesce(:total_inserted_rows, 0));
+            output := OBJECT_CONSTRUCT('oldest_running', :new_running, 'new_records', coalesce(:total_inserted_rows, 0), 'range_min', :range_min, 'range_max', :new_running);
         exception
             when other then
                 SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Exception occurred while refreshing ' || :wh_name || ' events.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -74,7 +74,7 @@ DECLARE
     start_time timestamp_ltz default (select current_timestamp());
     task_run_id text default (select INTERNAL.TASK_RUN_ID());
     query_id text default (select query_id from table(information_schema.task_history(TASK_NAME => 'WAREHOUSE_EVENTS_MAINTENANCE')) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
-    task_name text default 'WAREHOUSE_EVENTS';
+    task_name text default 'WAREHOUSE_EVENTS_MAINTENANCE';
     object_name text default 'WAREHOUSE_EVENTS_HISTORY';
 BEGIN
     let input variant := (select output from INTERNAL.TASK_LOG where success AND task_name = :task_name AND object_name = :object_name order by task_start desc limit 1);

--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -90,7 +90,7 @@ returns varchar
 language sql
 as
 declare
-    start_time timestamp default current_timestamp();
+    start_time text default (select current_timestamp()::TEXT);
     old_version varchar default NULL;
     setup_version varchar default internal.get_version();
     task_name text default 'UPGRADE_CHECK';

--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -90,7 +90,7 @@ returns varchar
 language sql
 as
 declare
-    start_time text default (select current_timestamp()::TEXT);
+    start_time timestamp_ntz default (select current_timestamp()::TIMESTAMP_NTZ);
     old_version varchar default NULL;
     setup_version varchar default internal.get_version();
     task_name text default 'UPGRADE_CHECK';

--- a/deploy/devdeploy_backfill.sql
+++ b/deploy/devdeploy_backfill.sql
@@ -1,20 +1,20 @@
 begin
     let dt timestamp := (select dateadd(day, -1, current_timestamp()));
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'WAREHOUSE_EVENTS', 'WAREHOUSE_EVENTS_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'QUERY_HISTORY', 'QUERY_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'SERVERLESS_TASK_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'TASK_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'SESSIONS';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'WAREHOUSE_METERING_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'LOGIN_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'HYBRID_TABLE_USAGE_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'MATERIALIZED_VIEW_REFRESH_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'QUERY_HISTORY_MAINTENANCE', 'QUERY_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'SERVERLESS_TASK_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'TASK_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'SESSIONS';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'WAREHOUSE_METERING_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'LOGIN_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'HYBRID_TABLE_USAGE_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'MATERIALIZED_VIEW_REFRESH_HISTORY';
 
     show warehouses;
     let res resultset := (select "name" as n from table(result_scan(last_query_id())));
     let cur cursor for res;
     for r in cur do
         let wh_name string := r.N;
-        insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'WAREHOUSE_LOAD_EVENT', :wh_name;
+        insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'WAREHOUSE_LOAD_MAINTENANCE', :wh_name;
     end for;
 end;

--- a/deploy/devdeploy_backfill.sql
+++ b/deploy/devdeploy_backfill.sql
@@ -1,18 +1,20 @@
 begin
     let dt timestamp := (select dateadd(day, -1, current_timestamp()));
-    insert into "{DATABASE}".INTERNAL.TASK_WAREHOUSE_EVENTS SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT;
-    insert into "{DATABASE}".INTERNAL.TASK_QUERY_HISTORY SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT;
-
-    insert into "{DATABASE}".INTERNAL.TASK_SIMPLE_DATA_EVENTS SELECT current_timestamp(), true, 'SERVERLESS_TASK_HISTORY', null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT;
-    insert into "{DATABASE}".INTERNAL.TASK_SIMPLE_DATA_EVENTS SELECT current_timestamp(), true, 'TASK_HISTORY', null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT;
-    insert into "{DATABASE}".INTERNAL.TASK_SIMPLE_DATA_EVENTS SELECT current_timestamp(), true, 'SESSIONS', null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT;
-    insert into "{DATABASE}".INTERNAL.TASK_SIMPLE_DATA_EVENTS SELECT current_timestamp(), true, 'WAREHOUSE_METERING_HISTORY', null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT;
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'WAREHOUSE_EVENTS', 'WAREHOUSE_EVENTS_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'QUERY_HISTORY', 'QUERY_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'SERVERLESS_TASK_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'TASK_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'SESSIONS';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'WAREHOUSE_METERING_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'LOGIN_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'HYBRID_TABLE_USAGE_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENT', 'MATERIALIZED_VIEW_REFRESH_HISTORY';
 
     show warehouses;
     let res resultset := (select "name" as n from table(result_scan(last_query_id())));
     let cur cursor for res;
     for r in cur do
         let wh_name string := r.N;
-        insert into "{DATABASE}".INTERNAL.TASK_WAREHOUSE_LOAD_EVENTS SELECT current_timestamp(), true, :wh_name, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT;
+        insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, object_type, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'WAREHOUSE_LOAD_EVENT', :wh_name;
     end for;
 end;

--- a/deploy/devdeploy_backfill.sql
+++ b/deploy/devdeploy_backfill.sql
@@ -1,7 +1,10 @@
 begin
     let dt timestamp := (select dateadd(day, -1, current_timestamp()));
+    let wh_output object := OBJECT_CONSTRUCT('oldest_running', dt, 'newest_completed', dt, 'range_min', :dt, 'range_max', :dt, 'cluster_range_min', :dt, 'cluster_range_max', :dt, 'warehouse_range_min', :dt, 'warehouse_range_max', :dt);
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :wh_output, :dt, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :wh_output, :dt, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_SESSIONS';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :wh_output, :dt, 'WAREHOUSE_EVENTS_MAINTENANCE', 'CLUSTER_SESSIONS';
     let output object := OBJECT_CONSTRUCT('oldest_running', dt, 'newest_completed', dt, 'range_min', :dt, 'range_max', :dt);
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY';
     insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'QUERY_HISTORY_MAINTENANCE', 'QUERY_HISTORY';
     insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'SERVERLESS_TASK_HISTORY';
     insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'TASK_HISTORY';

--- a/deploy/devdeploy_backfill.sql
+++ b/deploy/devdeploy_backfill.sql
@@ -1,20 +1,20 @@
 begin
     let dt timestamp := (select dateadd(day, -1, current_timestamp()));
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'QUERY_HISTORY_MAINTENANCE', 'QUERY_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'SERVERLESS_TASK_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'TASK_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'SESSIONS';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'WAREHOUSE_METERING_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'LOGIN_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'HYBRID_TABLE_USAGE_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'MATERIALIZED_VIEW_REFRESH_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'QUERY_HISTORY_MAINTENANCE', 'QUERY_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'SERVERLESS_TASK_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'TASK_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'SESSIONS';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'WAREHOUSE_METERING_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'LOGIN_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'HYBRID_TABLE_USAGE_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'MATERIALIZED_VIEW_REFRESH_HISTORY';
 
     show warehouses;
     let res resultset := (select "name" as n from table(result_scan(last_query_id())));
     let cur cursor for res;
     for r in cur do
         let wh_name string := r.N;
-        insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT current_timestamp(), true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'WAREHOUSE_LOAD_MAINTENANCE', :wh_name;
+        insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'WAREHOUSE_LOAD_MAINTENANCE', :wh_name;
     end for;
 end;

--- a/deploy/devdeploy_backfill.sql
+++ b/deploy/devdeploy_backfill.sql
@@ -1,20 +1,21 @@
 begin
     let dt timestamp := (select dateadd(day, -1, current_timestamp()));
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt, 'newest_completed', :dt)::VARIANT, :dt, 'QUERY_HISTORY_MAINTENANCE', 'QUERY_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'SERVERLESS_TASK_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'TASK_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'SESSIONS';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'WAREHOUSE_METERING_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'LOGIN_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'HYBRID_TABLE_USAGE_HISTORY';
-    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'MATERIALIZED_VIEW_REFRESH_HISTORY';
+    let output object := OBJECT_CONSTRUCT('oldest_running', dt, 'newest_completed', dt, 'range_min', :dt, 'range_max', :dt);
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'WAREHOUSE_EVENTS_MAINTENANCE', 'WAREHOUSE_EVENTS_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'QUERY_HISTORY_MAINTENANCE', 'QUERY_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'SERVERLESS_TASK_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'TASK_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'SESSIONS';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'WAREHOUSE_METERING_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'LOGIN_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'HYBRID_TABLE_USAGE_HISTORY';
+    insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'SIMPLE_DATA_EVENTS_MAINTENANCE', 'MATERIALIZED_VIEW_REFRESH_HISTORY';
 
     show warehouses;
     let res resultset := (select "name" as n from table(result_scan(last_query_id())));
     let cur cursor for res;
     for r in cur do
         let wh_name string := r.N;
-        insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, OBJECT_CONSTRUCT('oldest_running', :dt)::VARIANT, :dt, 'WAREHOUSE_LOAD_MAINTENANCE', :wh_name;
+        insert into "{DATABASE}".INTERNAL.TASK_LOG(task_start, success, input, output, task_finish, task_name, object_name) SELECT :dt, true, null, :output, :dt, 'WAREHOUSE_LOAD_MAINTENANCE', :wh_name;
     end for;
 end;

--- a/test/unit/test_materialization.py
+++ b/test/unit/test_materialization.py
@@ -52,6 +52,7 @@ def test_query_history_migration(conn):
 
 def test_task_log(conn):
     with conn() as cnx, cnx.cursor(DictCursor) as cur:
+        # Get the latest QH and WEH rows
         rows = cur.execute(
             """SELECT * FROM REPORTING.TASK_LOG_HISTORY
             WHERE TASK_NAME IN ('QUERY_HISTORY_MAINTENANCE', 'WAREHOUSE_EVENTS_MAINTENANCE')
@@ -62,10 +63,9 @@ def test_task_log(conn):
         """
         ).fetchall()
 
-        # devdeploy waits for QH and WEH to run. We can do a basic verification over task log.
+        # Do some basic verification over the two, make sure fields are filled in.
         for task_name in ["QUERY_HISTORY_MAINTENANCE", "WAREHOUSE_EVENTS_MAINTENANCE"]:
             task_log_row = next(row for row in rows if row["TASK_NAME"] == task_name)
-            print(f"Task log row: {task_log_row}")
 
             assert task_log_row["SUCCESS"] is True
             assert task_log_row["TASK_RUN_ID"] is not None
@@ -74,7 +74,6 @@ def test_task_log(conn):
             assert task_log_row["OUTPUT"] is not None
 
             output = json.loads(task_log_row["OUTPUT"])
-            print(f"Output: {output}, {type(output['attempted_migrate'])}")
             assert "attempted_migrate" in output
             assert output["attempted_migrate"] is True
             assert "new_records" in output

--- a/test/unit/test_materialization.py
+++ b/test/unit/test_materialization.py
@@ -79,11 +79,19 @@ def test_task_log(conn):
             assert output["attempted_migrate"] is True
             assert "new_records" in output
             assert isinstance(output["new_records"], int)
-            assert "range_min" in output
-            assert datetime.datetime.strptime(
-                output["range_min"], "%Y-%m-%d %H:%M:%S.%f"
-            )
-            assert "range_max" in output
-            assert datetime.datetime.strptime(
-                output["range_max"], "%Y-%m-%d %H:%M:%S.%f"
-            )
+            if task_name == "WAREHOUSE_EVENTS_MAINTENANCE":
+                # WEH is different in that we extract two different kinds of data from the same task/source-view.
+                fields = [
+                    "cluster_range_min",
+                    "cluster_range_max",
+                    "warehouse_range_min",
+                    "warehouse_range_max",
+                ]
+            else:
+                fields = ["range_min", "range_max"]
+
+            for f in fields:
+                assert f in output, f"Expected field {f} in output: {output}"
+                assert datetime.datetime.strptime(
+                    output[f], "%Y-%m-%d %H:%M:%S.%f"
+                ), f"Expected field {f} to be a datetime: {output[f]}"

--- a/test/unit/test_materialization.py
+++ b/test/unit/test_materialization.py
@@ -114,7 +114,7 @@ def test_start_finish_task(conn):
         )
 
         # internal.start_task(task_name text, object_name text, start_time text, task_run_id text, query_id text)
-        task_start = "2021-01-01 00:00:00.000"
+        task_start = "2021-01-01 00:00:00.000000"
         run_id = "test_run_id"
         query_id = "test_query_id"
         row = cur.execute(
@@ -151,7 +151,7 @@ def test_start_finish_task(conn):
             "oldest_running": "2021-12-31 23:45:00",
         }
         cur.execute(
-            f"CALL INTERNAL.FINISH_TASK('test_task', 'test_object', '{task_start}', '{run_id}', '{json.dump(output)}')"
+            f"CALL INTERNAL.FINISH_TASK('test_task', 'test_object', '{task_start}'::TIMESTAMP_NTZ, '{run_id}', PARSE_JSON('{json.dumps(output)}'))"
         ).fetchone()
 
         rows = cur.execute(
@@ -167,7 +167,7 @@ def test_start_finish_task(conn):
         # And that we have new fields now.
         assert rows[0]["SUCCESS"] is True
         assert rows[0]["TASK_FINISH"] is not None
-        assert_is_datetime(rows[0]["TASK_FINISH"])
+        assert isinstance(rows[0]["TASK_FINISH"], datetime.datetime)
         assert rows[0]["OUTPUT"] is not None
         actual_output = json.loads(rows[0]["OUTPUT"])
         assert (

--- a/test/unit/test_materialization.py
+++ b/test/unit/test_materialization.py
@@ -2,6 +2,14 @@ import datetime
 import json
 from snowflake.connector.cursor import DictCursor
 
+TIMESTAMP_PATTERN = "%Y-%m-%d %H:%M:%S.%f"
+
+
+def assert_is_datetime(s: str):
+    assert datetime.datetime.strptime(
+        s, TIMESTAMP_PATTERN
+    ), f"Expected value to be a datetime: {s}"
+
 
 def test_query_history_migration(conn):
     with conn() as cnx, cnx.cursor() as cur:
@@ -93,5 +101,75 @@ def test_task_log(conn):
             for f in fields:
                 assert f in output, f"Expected field {f} in output: {output}"
                 assert datetime.datetime.strptime(
-                    output[f], "%Y-%m-%d %H:%M:%S.%f"
+                    output[f], TIMESTAMP_PATTERN
                 ), f"Expected field {f} to be a datetime: {output[f]}"
+
+
+def test_start_finish_task(conn):
+    with conn() as cnx, cnx.cursor(DictCursor) as cur:
+        task_name = "test_task"
+        object_name = "test_object"
+        cur.execute(
+            f"DELETE FROM INTERNAL.TASK_LOG WHERE TASK_NAME = '{task_name}' AND OBJECT_NAME = '{object_name}'"
+        )
+
+        # internal.start_task(task_name text, object_name text, start_time text, task_run_id text, query_id text)
+        task_start = "2021-01-01 00:00:00.000"
+        run_id = "test_run_id"
+        query_id = "test_query_id"
+        row = cur.execute(
+            f"CALL INTERNAL.START_TASK('test_task', 'test_object', '{task_start}', '{run_id}', '{query_id}')"
+        ).fetchone()
+
+        assert row["START_TASK"] is None, "Expected not to find an input to be None"
+
+        rows = cur.execute(
+            f"select * from internal.task_log where task_name = '{task_name}' and object_name = '{object_name}'"
+        ).fetchall()
+        assert len(rows) == 1
+
+        assert rows[0]["TASK_START"].strftime(TIMESTAMP_PATTERN) == task_start
+        assert rows[0]["TASK_RUN_ID"] == run_id
+        assert rows[0]["QUERY_ID"] == query_id
+        for f in [
+            "TASK_FINISH",
+            "INPUT",
+            "OUTPUT",
+            "SUCCESS",
+            "RANGE_MIN",
+            "RANGE_MAX",
+        ]:
+            assert rows[0][f] is None, f"Expected field {f} to be None: {rows[0][f]}"
+
+        output = {
+            "new_records": 100,
+            "new_INCOMPLETE": 1,
+            "new_closed": 99,
+            "range_min": "2021-01-01 00:00:00",
+            "range_max": "2021-12-31 23:59:00",
+            "newest_completed": "2021-12-31 23:59:00",
+            "oldest_running": "2021-12-31 23:45:00",
+        }
+        cur.execute(
+            f"CALL INTERNAL.FINISH_TASK('test_task', 'test_object', '{task_start}', '{run_id}', '{json.dump(output)}')"
+        ).fetchone()
+
+        rows = cur.execute(
+            f"select * from internal.task_log where task_name = '{task_name}' and object_name = '{object_name}'"
+        ).fetchall()
+        assert len(rows) == 1
+
+        # Check that the old fields are still set
+        assert rows[0]["TASK_START"].strftime(TIMESTAMP_PATTERN) == task_start
+        assert rows[0]["TASK_RUN_ID"] == run_id
+        assert rows[0]["QUERY_ID"] == query_id
+
+        # And that we have new fields now.
+        assert rows[0]["SUCCESS"] is True
+        assert rows[0]["TASK_FINISH"] is not None
+        assert_is_datetime(rows[0]["TASK_FINISH"])
+        assert rows[0]["OUTPUT"] is not None
+        actual_output = json.loads(rows[0]["OUTPUT"])
+        assert (
+            actual_output == output
+        ), f"Expected output to be {output}, got {actual_output}"

--- a/test/unit/test_materialization.py
+++ b/test/unit/test_materialization.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 from snowflake.connector.cursor import DictCursor
 
@@ -78,3 +79,11 @@ def test_task_log(conn):
             assert output["attempted_migrate"] is True
             assert "new_records" in output
             assert isinstance(output["new_records"], int)
+            assert "range_min" in output
+            assert datetime.datetime.strptime(
+                output["range_min"], "%Y-%m-%d %H:%M:%S.%f"
+            )
+            assert "range_max" in output
+            assert datetime.datetime.strptime(
+                output["range_max"], "%Y-%m-%d %H:%M:%S.%f"
+            )


### PR DESCRIPTION
Suggestion from Jacques on Friday after we discussed the slow performance of #643 (due to the task_history and query_history UDTFs).

* Separate what a task does from the metadata recording that we want to track
* Record the query_id for a task when it runs into that metadata
* Migrate the separate task log tables into one (with even context to filter the update of a specific object)