### PR TITLE
Call start_task/finish_task in the task, not in the procedure.

### DIFF
--- a/bootstrap/092_service_account_setup.sql
+++ b/bootstrap/092_service_account_setup.sql
@@ -3,6 +3,7 @@ DROP PROCEDURE IF EXISTS admin.finalize_setup_from_service_account(varchar, varc
 CREATE OR REPLACE PROCEDURE admin.finalize_setup_from_service_account(api_integration_ref_id varchar, url varchar, web_url varchar, token varchar default null)
 RETURNS object
 LANGUAGE sql
+COMMENT = 'Deprecated: unused after parallelism improvements, to be removed'
 as
 begin
     -- Create the task so we can run finalize_setup asynchronously (duplicated in finalize_setup)
@@ -52,7 +53,23 @@ BEGIN
         ALLOW_OVERLAPPING_EXECUTION = FALSE
         USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = "XSMALL"
         AS
-        CALL ADMIN.UPGRADE_CHECK();
+    declare
+        start_time timestamp_ntz default (select current_timestamp()::TIMESTAMP_NTZ);
+        setup_version varchar default internal.get_version();
+        task_name text default 'UPGRADE_CHECK';
+        root_task_id text default (select INTERNAL.ROOT_TASK_ID());
+        task_run_id text default (select INTERNAL.TASK_RUN_ID());
+    begin
+        let query_id text := (select query_id from table(information_schema.task_history(TASK_NAME => :task_name, ROOT_TASK_ID => :root_task_id)) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
+        let input object;
+        CALL INTERNAL.START_TASK(:task_name, :setup_version, :start_time, :task_run_id, :query_id) into :input;
+
+        let output object;
+        CALL ADMIN.UPGRADE_CHECK() into :output;
+
+        CALL INTERNAL.FINISH_TASK(:task_name, :setup_version, :start_time, :task_run_id, :output);
+    END;
+
     grant MONITOR, OPERATE on TASK TASKS.UPGRADE_CHECK to APPLICATION ROLE ADMIN;
     return '';
 END;
@@ -86,42 +103,30 @@ END;
 
 
 CREATE OR REPLACE PROCEDURE admin.upgrade_check()
-returns varchar
+returns object
 language sql
 as
 declare
-    start_time timestamp_ntz default (select current_timestamp()::TIMESTAMP_NTZ);
     old_version varchar default NULL;
     setup_version varchar default internal.get_version();
-    task_name text default 'UPGRADE_CHECK';
-    root_task_id text default (select INTERNAL.ROOT_TASK_ID());
-    task_run_id text default (select INTERNAL.TASK_RUN_ID());
 begin
-    let query_id text := (select query_id from table(information_schema.task_history(TASK_NAME => :task_name, ROOT_TASK_ID => :root_task_id)) WHERE GRAPH_RUN_GROUP_ID = :task_run_id  AND DATABASE_NAME = current_database() limit 1);
-    let input object;
-    CALL INTERNAL.START_TASK(:task_name, :setup_version, :start_time, :task_run_id, :query_id) into :input;
+    let output object;
+    -- It is important that we always call this procedure. If the Sundeck token is regenerated, we need to also recreate
+    -- the external functions. ADMIN.FINALIZE_SETUP does also call setup_external_functions, but this task only runs
+    -- finalize_setup once per native app version.
+    CALL admin.setup_external_functions('opscenter_api_integration');
 
-    let output variant;
-    BEGIN
-        -- It is important that we always call this procedure. If the Sundeck token is regenerated, we need to also recreate
-        -- the external functions. ADMIN.FINALIZE_SETUP does also call setup_external_functions, but this task only runs
-        -- finalize_setup once per native app version.
-        CALL admin.setup_external_functions('opscenter_api_integration');
+    call internal.get_config('post_setup') into :old_version;
+    let ran_finalize_setup boolean := false;
+    if (old_version is null or old_version <> setup_version) then
+        call admin.finalize_setup();
+        ran_finalize_setup := true;
+    end if;
 
-        call internal.get_config('post_setup') into :old_version;
-        let ran_finalize_setup boolean := false;
-        if (old_version is null or old_version <> setup_version) then
-            call admin.finalize_setup();
-            ran_finalize_setup := true;
-        end if;
-
-        output := OBJECT_CONSTRUCT('old_version', :old_version, 'new_version', :setup_version, 'finalize_setup', :ran_finalize_setup);
-    EXCEPTION
-        WHEN OTHER THEN
-            SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Unhandled exception occurred during UPGRADE_CHECK.', 'SQLCODE', :sqlcode,
-                'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
-            output := OBJECT_CONSTRUCT('error', 'Unhandled exception occurred during UPGRADE_CHECK.', 'SQLCODE', :sqlcode, 'SQLSTATE', :sqlstate, 'SQLERRM', :sqlerrm);
-    END;
-
-    CALL INTERNAL.FINISH_TASK(:task_name, :setup_version, :start_time, :task_run_id, :output);
-end;
+    return OBJECT_CONSTRUCT('old_version', :old_version, 'new_version', :setup_version, 'finalize_setup', :ran_finalize_setup);
+EXCEPTION
+    WHEN OTHER THEN
+        SYSTEM$LOG_ERROR(OBJECT_CONSTRUCT('error', 'Unhandled exception occurred during UPGRADE_CHECK.', 'SQLCODE', :sqlcode,
+            'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate));
+        return OBJECT_CONSTRUCT('error', 'Unhandled exception occurred during UPGRADE_CHECK.', 'SQLCODE', :sqlcode, 'SQLSTATE', :sqlstate, 'SQLERRM', :sqlerrm);
+END;


### PR DESCRIPTION
We cannot call task_history from within a stored procedure. Forgot to update this one case because it is in the 092 file rather than 090 like the rest of the instances.

Other things:
- [ ] we can drop `admin.finalize_setup_from_service_account`. will do that in a separate PR
- [ ] we should add a test which verifies that calling `call admin.create_upgrade_check_task();` and `execute task tasks.upgrade_check;` results in the same outcome as if we had called `admin.finalize_setup()` directly (e.g. entries show up in catalog.config). I don't want to run 2 materializations on every PR, so I'm going to see how we add that separately.