### PR TITLE
Create a task to mark old, incomplete task_log rows as FAILED

### DIFF
--- a/bootstrap/012_task_log.sql
+++ b/bootstrap/012_task_log.sql
@@ -13,19 +13,26 @@ $$
      SYSTEM$TASK_RUNTIME_INFO('CURRENT_TASK_GRAPH_RUN_GROUP_ID')
 $$;
 
+-- prevent confusion with the overloaded procedure defined below
+drop procedure if exists internal.start_task(text, text, timestamp_ntz, text, text);
+
 -- Inserts a row into TASK_LOG with the time the task started, the name of the object being materialized, the graph run ID and query_id for the task.
-create or replace procedure internal.start_task(task_name text, object_name text, task_run_id text, query_id text)
+create or replace procedure internal.start_task(task_name text, object_name text, task_run_id text, query_id text,
+        task_log_table text default 'INTERNAL.TASK_LOG', query_history_table text default 'SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY')
     returns object
     language sql
 AS
 BEGIN
-    let start_time timestamp_ltz := (select current_timestamp());
-    let input object := (select output from INTERNAL.TASK_LOG where success AND task_name = :task_name AND object_name = :object_name order by task_start desc limit 1);
+    -- Clean up any outstanding rows for this task that have `success is null`. We are relying on the fact that this procedure is called
+    -- when a task begins and all tasks in the NativeApp disallow concurrent execution (else, we may try to update a row for a task still running).
+    CALL INTERNAL.CLOSE_LOG_FOR_TASK(:task_log_table, :query_history_table, :task_name, :object_name);
+
+    let input object := (select output from IDENTIFIER(:task_log_table) where success AND task_name = :task_name AND object_name = :object_name order by task_start desc limit 1);
     -- Set the previous range_min/max when we start a task to avoid a look-back in admin.materialization_status
     let range_min timestamp_ltz := (select :input['range_min']);
     let range_max timestamp_ltz := (select :input['range_max']);
-    INSERT INTO INTERNAL.TASK_LOG(task_start, task_run_id, query_id, input, task_name, object_name, range_min, range_max)
-        select :start_time, :task_run_id, :query_id, :input, :task_name, :object_name, :range_min, :range_max;
+    INSERT INTO IDENTIFIER(:task_log_table)(task_start, task_run_id, query_id, input, task_name, object_name, range_min, range_max)
+				select current_timestamp(), :task_run_id, :query_id, :input, :task_name, :object_name, :range_min, :range_max;
     return input;
 END;
 
@@ -80,3 +87,51 @@ CREATE OR REPLACE VIEW ADMIN.TASK_LOG_HISTORY AS SELECT * FROM INTERNAL.TASK_LOG
 
 -- Remove view from old location
 DROP VIEW IF EXISTS REPORTING.TASK_LOG_HISTORY;
+
+CREATE OR REPLACE PROCEDURE INTERNAL.CLOSE_LOG_FOR_TASK(task_log_table text, query_history_table text, task_name text, object_name text)
+    RETURNS OBJECT
+    LANGUAGE SQL
+    Comment = 'Closes an open task log rows for the given task name and object name. Intended to be called at the start of each task.'
+AS
+BEGIN
+    -- Mark records for the given task_name and object_name that are still "open" (success is null) as having failed.
+    update identifier(:task_log_table)
+    set success = false, output = details.output, task_finish = current_timestamp()
+    from (
+        with open_queries as (
+            select
+                query_id,
+                task_name,
+                object_name,
+                task_run_id,
+                'Could not find query history for task=' || task_name || ', object=' || object_name || ', task_run_id=' || task_run_id || ', query_id=' || COALESCE(query_id, 'NULL') as default_msg,
+                OBJECT_CONSTRUCT('FORCE_CLOSED', true) as closed_output
+            from identifier(:task_log_table) where success is null
+        ), open_query_details as (
+            -- Limit the query history lookback to one day to avoid pulling back too many rows from the secure view
+            select
+                query_id,
+                object_construct(*) as details
+            from identifier(:query_history_table)
+            where query_id in (select query_id from open_queries where query_id is not null) and start_time > current_timestamp() - interval '1 day'
+        )
+        select oq.query_id, oq.task_name, oq.object_name, task_run_id,
+            case
+                when qd.details is not null then INTERNAL.MERGE_OBJECTS(oq.closed_output, qd.details)
+                else OBJECT_INSERT(oq.closed_output, 'details', oq.default_msg)
+            end as output,
+        from open_queries oq
+        left join open_query_details qd on oq.query_id = qd.query_id
+    ) as details
+    where details.query_id = task_log.query_id and details.task_run_id = task_log.task_run_id and task_log.success is null;
+
+    let o object := (select OBJECT_CONSTRUCT('success', TRUE, 'rows_closed', "number of rows updated") from table(result_scan(last_query_id())));
+
+    SYSTEM$LOG_INFO(:o);
+    return o;
+EXCEPTION
+    WHEN OTHER THEN
+        let o object := OBJECT_CONSTRUCT('error', 'Exception trying to close outstanding task rows.', 'SQLCODE', :sqlcode, 'SQLERRM', :sqlerrm, 'SQLSTATE', :sqlstate);
+        SYSTEM$LOG_ERROR(:o);
+        return o;
+END;

--- a/bootstrap/012_task_log.sql
+++ b/bootstrap/012_task_log.sql
@@ -14,7 +14,7 @@ $$
 $$;
 
 -- prevent confusion with the overloaded procedure defined below
-drop procedure if exists internal.start_task(text, text, timestamp_ntz, text, text);
+drop procedure if exists internal.start_task(text, text, text, text);
 
 -- Inserts a row into TASK_LOG with the time the task started, the name of the object being materialized, the graph run ID and query_id for the task.
 create or replace procedure internal.start_task(task_name text, object_name text, task_run_id text, query_id text,
@@ -32,7 +32,7 @@ BEGIN
     let range_min timestamp_ltz := (select :input['range_min']);
     let range_max timestamp_ltz := (select :input['range_max']);
     INSERT INTO IDENTIFIER(:task_log_table)(task_start, task_run_id, query_id, input, task_name, object_name, range_min, range_max)
-				select current_timestamp(), :task_run_id, :query_id, :input, :task_name, :object_name, :range_min, :range_max;
+        select current_timestamp(), :task_run_id, :query_id, :input, :task_name, :object_name, :range_min, :range_max;
     return input;
 END;
 
@@ -95,7 +95,7 @@ CREATE OR REPLACE PROCEDURE INTERNAL.CLOSE_LOG_FOR_TASK(task_log_table text, que
 AS
 BEGIN
     -- Mark records for the given task_name and object_name that are still "open" (success is null) as having failed.
-    update identifier(:task_log_table)
+    update identifier(:task_log_table) task_log
     set success = false, output = details.output, task_finish = current_timestamp()
     from (
         with open_queries as (

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -532,6 +532,7 @@ CREATE OR REPLACE TASK TASKS.WAREHOUSE_SCHEDULING
     as
     call INTERNAL.UPDATE_WAREHOUSE_SCHEDULES(NULL, NULL);
 
+
 -- This clarifies that the post setup script has been executed to match the current installed version.
 let version string := (select internal.get_version());
 call internal.set_config('post_setup', :version);

--- a/bootstrap/090_post_setup.sql
+++ b/bootstrap/090_post_setup.sql
@@ -532,7 +532,6 @@ CREATE OR REPLACE TASK TASKS.WAREHOUSE_SCHEDULING
     as
     call INTERNAL.UPDATE_WAREHOUSE_SCHEDULES(NULL, NULL);
 
-
 -- This clarifies that the post setup script has been executed to match the current installed version.
 let version string := (select internal.get_version());
 call internal.set_config('post_setup', :version);

--- a/test/unit/test_materialization.py
+++ b/test/unit/test_materialization.py
@@ -446,8 +446,8 @@ def test_close_stale_task_log(conn):
         # Start a new execution of the task "TEST_MAINTENANCE"
         cur.execute(
             f"""
-            CALL INTERNAL.START_TASK('TEST_MAINTENANCE', 'TEST_OBJECT', '2024-05-06 02:00:00'::TIMESTAMP_NTZ,
-                UUID_STRING(), '{new_query_id}', 'INTERNAL.TASK_LOG_TEST', 'INTERNAL.QUERY_HISTORY_TEST')
+            CALL INTERNAL.START_TASK('TEST_MAINTENANCE', 'TEST_OBJECT', UUID_STRING(), '{new_query_id}',
+                'INTERNAL.TASK_LOG_TEST', 'INTERNAL.QUERY_HISTORY_TEST')
         """
         )
 

--- a/test/unit/test_materialization.py
+++ b/test/unit/test_materialization.py
@@ -418,8 +418,8 @@ def test_close_stale_task_log(conn):
             f"""
             INSERT INTO INTERNAL.TASK_LOG_TEST(task_start, success, input, output, task_finish, task_name, object_name,
                 query_id, task_run_id, range_min, range_max)
-            SELECT '2024-05-06 00:00:00'::TIMESTAMP_NTZ, true, OBJECT_CONSTRUCT(), OBJECT_CONSTRUCT(),
-                '2024-05-06 00:10:00'::TIMESTAMP_NTZ, 'TEST_MAINTENANCE', 'TEST_OBJECT', '{complete_task_log_query_id}',
+            SELECT '2024-05-06 00:00:00'::TIMESTAMP_LTZ, true, OBJECT_CONSTRUCT(), OBJECT_CONSTRUCT(),
+                '2024-05-06 00:10:00'::TIMESTAMP_LTZ, 'TEST_MAINTENANCE', 'TEST_OBJECT', '{complete_task_log_query_id}',
                 UUID_STRING(), TIMESTAMPADD(day, -1, current_timestamp()), current_timestamp()
         """
         )
@@ -429,7 +429,7 @@ def test_close_stale_task_log(conn):
             f"""
             INSERT INTO INTERNAL.TASK_LOG_TEST(task_start, success, input, task_name, object_name,
                 query_id, task_run_id, range_min, range_max)
-            SELECT '2024-05-06 01:00:00'::TIMESTAMP_NTZ, NULL, OBJECT_CONSTRUCT(), 'TEST_MAINTENANCE',
+            SELECT '2024-05-06 01:00:00'::TIMESTAMP_LTZ, NULL, OBJECT_CONSTRUCT(), 'TEST_MAINTENANCE',
                 'TEST_OBJECT', '{failed_task_log_query_id}', UUID_STRING(), TIMESTAMPADD(day, -1, current_timestamp()),
                 current_timestamp()
         """
@@ -438,8 +438,10 @@ def test_close_stale_task_log(conn):
         # Create some query history rows to match
         cur.execute(
             f"""
-            INSERT INTO INTERNAL.QUERY_HISTORY_TEST(query_id, execution_status)
-            values ('{complete_task_log_query_id}', 'SUCCESS'), ('{failed_task_log_query_id}', 'INCIDENT')
+            INSERT INTO INTERNAL.QUERY_HISTORY_TEST(query_id, execution_status, start_time)
+            values
+                ('{complete_task_log_query_id}', 'SUCCESS', CURRENT_TIMESTAMP()),
+                ('{failed_task_log_query_id}', 'INCIDENT', CURRENT_TIMESTAMP())
         """
         )
 

--- a/test/unit/test_materialization.py
+++ b/test/unit/test_materialization.py
@@ -4,6 +4,7 @@ import time
 
 from snowflake.connector.cursor import DictCursor
 import unittest
+import uuid
 
 TIMESTAMP_PATTERN = "%Y-%m-%d %H:%M:%S.%f %Z"
 
@@ -128,6 +129,7 @@ def test_start_finish_task(conn):
         orig_task_start = rows[0]["TASK_START"]
         assert rows[0]["TASK_RUN_ID"] == run_id
         assert rows[0]["QUERY_ID"] == query_id
+        assert rows[0]["OBJECT_NAME"] == object_name
         for f in [
             "TASK_FINISH",
             "INPUT",
@@ -395,3 +397,77 @@ def test_migrate_old_warehouse_events_log(conn, current_timezone):
             cur.execute(
                 "DELETE FROM INTERNAL.TASK_LOG where task_name = 'WAREHOUSE_EVENTS_MAINTENANCE' and task_start::DATE <= '2020-01-30'::DATE"
             )
+
+
+def test_close_stale_task_log(conn):
+    with conn() as cnx, cnx.cursor(DictCursor) as cur:
+        cur.execute(
+            "CREATE OR REPLACE TABLE INTERNAL.TASK_LOG_TEST LIKE INTERNAL.TASK_LOG"
+        )
+        cur.execute(
+            "CREATE OR REPLACE TABLE INTERNAL.QUERY_HISTORY_TEST LIKE SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY"
+        )
+
+        # Create three rows. One that is success=true and complete, one that is success=null and incomplete, and one that is success=null and running.
+        complete_task_log_query_id = str(uuid.uuid4())
+        failed_task_log_query_id = str(uuid.uuid4())
+        new_query_id = str(uuid.uuid4())
+
+        # a successful, complete row
+        cur.execute(
+            f"""
+            INSERT INTO INTERNAL.TASK_LOG_TEST(task_start, success, input, output, task_finish, task_name, object_name,
+                query_id, task_run_id, range_min, range_max)
+            SELECT '2024-05-06 00:00:00'::TIMESTAMP_NTZ, true, OBJECT_CONSTRUCT(), OBJECT_CONSTRUCT(),
+                '2024-05-06 00:10:00'::TIMESTAMP_NTZ, 'TEST_MAINTENANCE', 'TEST_OBJECT', '{complete_task_log_query_id}',
+                UUID_STRING(), TIMESTAMPADD(day, -1, current_timestamp()), current_timestamp()
+        """
+        )
+
+        # a failed, incomplete row
+        cur.execute(
+            f"""
+            INSERT INTO INTERNAL.TASK_LOG_TEST(task_start, success, input, task_name, object_name,
+                query_id, task_run_id, range_min, range_max)
+            SELECT '2024-05-06 01:00:00'::TIMESTAMP_NTZ, NULL, OBJECT_CONSTRUCT(), 'TEST_MAINTENANCE',
+                'TEST_OBJECT', '{failed_task_log_query_id}', UUID_STRING(), TIMESTAMPADD(day, -1, current_timestamp()),
+                current_timestamp()
+        """
+        )
+
+        # Create some query history rows to match
+        cur.execute(
+            f"""
+            INSERT INTO INTERNAL.QUERY_HISTORY_TEST(query_id, execution_status)
+            values ('{complete_task_log_query_id}', 'SUCCESS'), ('{failed_task_log_query_id}', 'INCIDENT')
+        """
+        )
+
+        # Start a new execution of the task "TEST_MAINTENANCE"
+        cur.execute(
+            f"""
+            CALL INTERNAL.START_TASK('TEST_MAINTENANCE', 'TEST_OBJECT', '2024-05-06 02:00:00'::TIMESTAMP_NTZ,
+                UUID_STRING(), '{new_query_id}', 'INTERNAL.TASK_LOG_TEST', 'INTERNAL.QUERY_HISTORY_TEST')
+        """
+        )
+
+        # Verify the other task log is closed
+        rows = cur.execute(
+            "select * from internal.task_log_test where success = false"
+        ).fetchall()
+        assert len(rows) == 1, f"Expected 1 row, got {rows}"
+        assert rows[0]["QUERY_ID"] == failed_task_log_query_id
+
+        # Verify we put the query_history details into the OUTPUT object
+        assert rows[0]["OUTPUT"] is not None
+        output = json.loads(rows[0]["OUTPUT"])
+        assert output["EXECUTION_STATUS"] == "INCIDENT", f"Output was {output}"
+        # And the special marker that the row was closed
+        assert output["FORCE_CLOSED"] is True, f"Output was {output}"
+
+        # Verify that we still have the new row
+        rows = cur.execute(
+            "select * from internal.task_log_test where success is null"
+        ).fetchall()
+        assert len(rows) == 1, f"Expected 1 row, got {rows}"
+        assert rows[0]["QUERY_ID"] == new_query_id


### PR DESCRIPTION
* ~~Task runs every hour, looking for rows in internal.task_log where `SUCCESS IS NULL`~~
* ~~If the query_id is still running (blocked, queued, running) or we do not find the row in QUERY_HISTORY, we do nothing to the row.~~
* ~~If we have no query_id, mark the row as failed.~~
* When a task runs, we find all rows for the same task which are `success is null`
* If we have a `query_id` for that row, look up that query in the Snowflake query_history view and set it as the `output`
* Always include a `FORCE_CLOSED: true` attribute in the `output` object.

Sorry for some more procedural code from me. I tried a couple of different ways to run the UPDATE statement with a left-join against QUERY_HISTORY, but they were all brutally slow (cancelled the query after a minute of execution).

This will correct the admin.materialization_status view reporting the `NEXT_` columns as actively running when they are not actually running (easily noticed when the last incremental materialization has a newer start/finish than the `NEXT_` times).

(edited for description accuracy since fa4a45b)